### PR TITLE
Initial commit towards #49

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -11,3 +11,5 @@
 ^LICENSE\.md$
 .Rprofile
 ^cran-comments\.md$
+^doc$
+^Meta$

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ Meta
 .Ruserdata
 data
 .DS_Store
+doc

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,7 +28,8 @@ Imports:
     tidyr, 
     stringr,
     rsdmx, 
-    readr
+    readr,
+    tools
 URL: https://github.com/mattcowgill/readabs
 BugReports: https://github.com/mattcowgill/readabs/issues
 RoxygenNote: 6.1.1

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,6 +20,8 @@ Imports:
     readxl (>= 1.2.0), 
     tibble (>= 1.4.99),
     dplyr (>= 0.8.0), 
+    hutils (>= 1.5.0),
+    fst,
     XML,
     curl,
     purrr,

--- a/R/fst-utils.R
+++ b/R/fst-utils.R
@@ -1,0 +1,64 @@
+#' Internal functions for working with the fst cache
+#' @name fst-utils
+#' @noRd
+#'
+#' @param cat_no,path As in \code{\link{read_abs}}.
+#'
+#' @return For `catno2fst` the path to the `fst` file to be saved or read, given
+#' `cat_no` and `path`.
+#'
+#' `fst_available` returns `TRUE` if and only if an appropriate `fst` file is
+#' available.
+#'
+#' `ext2ext` changes the extension of the provided file to a file in the same
+#' path but with the provided extension.
+#'
+
+
+catno2fst <- function(cat_no,
+                      path = Sys.getenv("R_READABS_PATH", unset = tempdir())) {
+  hutils::provide.file(file.path(path,
+                                 "fst",
+                                 paste0(gsub(".", "-", cat_no, fixed = TRUE),
+                                        ".fst")),
+                       on_failure = stop("`path = ", normalizePath(path, winslash = "/"), "`, ",
+                                         "but it was not possible to write to this directory."))
+}
+
+fst_available <- function(cat_no,
+                          path = Sys.getenv("R_READABS_PATH", unset = tempdir())) {
+  if (!requireNamespace("fst", quietly = TRUE) ||
+      !dir.exists(path)) {
+    return(FALSE)
+  }
+
+  file.fst <- catno2fst(cat_no, path)
+
+  if (!file.exists(file.fst)) {
+    return(FALSE)
+  }
+
+  # fst may be damaged. If it appears to be (i.e. fst metadata returns an error)
+  #   return FALSE
+
+  # nocov start
+  out <- tryCatch(inherits(fst::fst.metadata(file.fst), "fstmetadata"),
+                  error = function(e) FALSE,
+                  warning = function(e) FALSE)
+  # nocov end
+  out
+}
+
+ext2ext <- function(file, new.ext) {
+  paste0(tools::file_path_sans_ext(file), new.ext)
+}
+
+
+
+
+
+
+
+
+
+

--- a/R/fst-utils.R
+++ b/R/fst-utils.R
@@ -42,17 +42,17 @@ fst_available <- function(cat_no,
   file.fst <- catno2fst(cat_no, path)
 
   if (!file.exists(file.fst)) {
-    return(FALSE)
+    return(FALSE)  # nocov
   }
 
   # fst may be damaged. If it appears to be (i.e. fst metadata returns an error)
   #   return FALSE
 
-  # nocov start
+
   out <- tryCatch(inherits(fst::fst.metadata(file.fst), "fstmetadata"),
                   error = function(e) FALSE,
                   warning = function(e) FALSE)
-  # nocov end
+
   out
 }
 

--- a/R/fst-utils.R
+++ b/R/fst-utils.R
@@ -32,6 +32,13 @@ fst_available <- function(cat_no,
     return(FALSE)
   }
 
+  if (!is.character(cat_no) ||
+      length(cat_no) != 1L ||
+      anyNA(cat_no) ||
+      nchar(cat_no) < 6L) {
+    return(FALSE)
+  }
+
   file.fst <- catno2fst(cat_no, path)
 
   if (!file.exists(file.fst)) {

--- a/R/read_abs.R
+++ b/R/read_abs.R
@@ -60,6 +60,7 @@ read_abs <- function(cat_no = NULL,
                      show_progress_bars = TRUE,
                      retain_files = TRUE){
 
+
   if(!is.logical(retain_files)){
     stop("The `retain_files` argument to `read_abs()` must be either TRUE or FALSE.")
   }
@@ -88,17 +89,27 @@ read_abs <- function(cat_no = NULL,
     stop("`metadata` argument must be either TRUE or FALSE")
   }
 
-  # create temp directory to temporarily store spreadsheets if retain_files == FALSE
-  if(!retain_files){
-    path <- tempdir()
+
+  if (fst_available(cat_no = cat_no, path = path)) {
+    out <- fst::read_fst(catno2fst(cat_no = cat_no, path = path))
+    return(tibble::as_tibble(out))
   }
+
+
 
   # satisfy CRAN
   ProductReleaseDate=SeriesID=NULL
 
   # create a subdirectory of 'path' corresponding to the catalogue number if specified
-  if(retain_files & !is.null(cat_no)){
-    path <- file.path(path, cat_no)
+  if (retain_files && !is.null(cat_no)){
+    .path <- file.path(path, cat_no)
+  } else {
+    # create temp directory to temporarily store spreadsheets if retain_files == FALSE
+    if(!retain_files) {
+      .path <- tempdir()
+    } else {
+      .path <- path
+    }
   }
 
   # check that R has access to the internet
@@ -143,13 +154,14 @@ read_abs <- function(cat_no = NULL,
   # download tables corresponding to URLs
   message(paste0("Attempting to download files from ", download_message,
                  ", ", xml_dfs$ProductTitle[1]))
-  purrr::walk(urls, download_abs, path = path, show_progress_bars = show_progress_bars)
+  purrr::walk(urls, download_abs, path = .path, show_progress_bars = show_progress_bars)
 
   # extract the sheets to a list
   filenames <- base::basename(urls)
   message("Extracting data from downloaded spreadsheets")
   sheets <- purrr::map2(filenames, table_titles,
-                       .f = extract_abs_sheets, path = path)
+                       .f = extract_abs_sheets,
+                       path = .path)
 
   # remove one 'layer' of the list, so that each sheet is its own element in the list
   sheets <- unlist(sheets, recursive = FALSE)
@@ -160,7 +172,7 @@ read_abs <- function(cat_no = NULL,
   # remove spreadsheets from disk if `retain_files` == FALSE
   if(!retain_files){
     # delete downloaded files
-    file.remove(file.path(path, filenames))
+    file.remove(file.path(.path, filenames))
   }
 
   # if series_id is specified, remove all other series_ids
@@ -172,6 +184,28 @@ read_abs <- function(cat_no = NULL,
     sheet <- sheet %>%
       dplyr::filter(series_id %in% users_series_id)
 
+  }
+
+  # if fst is available, write the cache to the <path>/fst/ file
+  if (retain_files && requireNamespace("fst", quietly = TRUE)) {
+    fst::write_fst(sheet,
+                   catno2fst(cat_no = cat_no,
+                             path = path))
+
+    if (metadata) {
+      fstMD5 <- tools::md5sum(catno2fst(cat_no = cat_no, path = path))
+      theProductReleaseDate <-
+        if (utils::hasName(sheet, "ProductReleaseDate")) {
+          (sheet[["ProductReleaseDate"]])[1L]
+        } else {
+          NA_real_
+        }
+      write.dcf(tibble::tibble(fst_MD5 = fstMD5,
+                               ProductReleaseDate = theProductReleaseDate),
+                ext2ext(catno2fst(cat_no = cat_no,
+                                  path = path),
+                        ".dcf"))
+    }
   }
 
   # return a data frame

--- a/R/read_abs.R
+++ b/R/read_abs.R
@@ -60,7 +60,6 @@ read_abs <- function(cat_no = NULL,
                      show_progress_bars = TRUE,
                      retain_files = TRUE){
 
-
   if(!is.logical(retain_files)){
     stop("The `retain_files` argument to `read_abs()` must be either TRUE or FALSE.")
   }
@@ -160,8 +159,7 @@ read_abs <- function(cat_no = NULL,
   filenames <- base::basename(urls)
   message("Extracting data from downloaded spreadsheets")
   sheets <- purrr::map2(filenames, table_titles,
-                       .f = extract_abs_sheets,
-                       path = .path)
+                       .f = extract_abs_sheets, path = .path)
 
   # remove one 'layer' of the list, so that each sheet is its own element in the list
   sheets <- unlist(sheets, recursive = FALSE)

--- a/R/read_abs.R
+++ b/R/read_abs.R
@@ -89,7 +89,7 @@ read_abs <- function(cat_no = NULL,
   }
 
 
-  if (fst_available(cat_no = cat_no, path = path)) {
+  if (is.null(series_id) && fst_available(cat_no = cat_no, path = path)) {
     out <- fst::read_fst(catno2fst(cat_no = cat_no, path = path))
     return(tibble::as_tibble(out))
   }
@@ -184,8 +184,12 @@ read_abs <- function(cat_no = NULL,
 
   }
 
-  # if fst is available, write the cache to the <path>/fst/ file
-  if (retain_files && requireNamespace("fst", quietly = TRUE)) {
+  # if fst is available, and what has been requested is the full data,
+  #  write the result to the <path>/fst/ file
+  if (retain_files &&
+      is.null(series_id) &&
+      identical(tables, "all") &&
+      requireNamespace("fst", quietly = TRUE)) {
     fst::write_fst(sheet,
                    catno2fst(cat_no = cat_no,
                              path = path))

--- a/R/read_abs.R
+++ b/R/read_abs.R
@@ -193,7 +193,7 @@ read_abs <- function(cat_no = NULL,
     if (metadata) {
       fstMD5 <- tools::md5sum(catno2fst(cat_no = cat_no, path = path))
       theProductReleaseDate <-
-        if (utils::hasName(sheet, "ProductReleaseDate")) {
+        if ("ProductReleaseDate" %in% names(sheet)) {
           (sheet[["ProductReleaseDate"]])[1L]
         } else {
           NA_real_

--- a/man/read_abs.Rd
+++ b/man/read_abs.Rd
@@ -24,7 +24,7 @@ to specifying `cat_no`.}
 spreadsheets. By default, `path` takes the value set in the environment variable
 "R_READABS_PATH". To check the value of this variable, run \code{Sys.getenv("R_READABS_PATH")}.
 If this variable is not set, the files downloaded by read_abs()
-will be stored in a temporary directory (`tempdir()`).}
+will be stored in a temporary directory (\code{tempdir()}).}
 
 \item{metadata}{logical. If `TRUE` (the default), a tidy data frame including
 ABS metadata (series name, table name, etc.) is included in the output. If

--- a/man/read_abs.Rd
+++ b/man/read_abs.Rd
@@ -6,7 +6,8 @@
 \usage{
 read_abs(cat_no = NULL, tables = "all", series_id = NULL,
   path = Sys.getenv("R_READABS_PATH", unset = tempdir()),
-  metadata = TRUE, show_progress_bars = TRUE, retain_files = TRUE)
+  metadata = TRUE, show_progress_bars = TRUE, retain_files = TRUE,
+  check_local = TRUE)
 }
 \arguments{
 \item{cat_no}{ABS catalogue number, as a string, including the extension.
@@ -36,6 +37,8 @@ will not be shown when ABS spreadsheets are downloading.}
 \item{retain_files}{when TRUE (the default), the spreadsheets downloaded from the
 ABS website will be saved in the directory specified with `path`. If set to `FALSE`,
 the files will be stored in a temporary directory.}
+
+\item{check_local}{If `TRUE`, the default, local `fst` files are used, if present.}
 }
 \value{
 A data frame (tibble) containing the tidied data from the ABS time

--- a/man/read_abs_local.Rd
+++ b/man/read_abs_local.Rd
@@ -6,7 +6,7 @@
 \usage{
 read_abs_local(cat_no = NULL, filenames = NULL,
   path = Sys.getenv("R_READABS_PATH", unset = tempdir()),
-  metadata = TRUE)
+  use_fst = TRUE, metadata = TRUE)
 }
 \arguments{
 \item{cat_no}{character; a single catalogue number such as "6202.0". When `cat_no`
@@ -24,6 +24,9 @@ Ignored if a value is supplied to `cat_no`. If `filenames` is blank and `cat_no`
 Default is `Sys.getenv("R_READABS_PATH", unset = tempdir())`.
  If nothing is specified in `filenames` or `cat_no`,
 `read_abs_local()` will attempt to read all .xls files in the directory specified with `path`.}
+
+\item{use_fst}{logical. If `TRUE` (the default) then, if an `fst` file of the
+tidy data frame has already been saved in `path`, it is read immediately.}
 
 \item{metadata}{logical. If `TRUE` (the default), a tidy data frame including
 ABS metadata (series name, table name, etc.) is included in the output. If

--- a/tests/testthat/test-fst.R
+++ b/tests/testthat/test-fst.R
@@ -1,0 +1,34 @@
+check_abs_site <- function() {
+  if(is.null(curl::nslookup("abs.gov.au", error = FALSE))){
+    skip("ABS Time Series Directory not available")
+  }
+}
+
+
+test_that("read_abs works out of the box", {
+  skip_on_cran()
+  check_abs_site()
+  out6401_init <- read_abs(cat_no = "6401.0")
+  skip_if_not(file.exists(catno2fst("6401.0")))
+  out6401_next <- read_abs(cat_no = "6401.0")
+
+  # Bug in dplyr equal_data_frame()
+  expect_equal(as.data.frame(out6401_init),
+               as.data.frame(out6401_next))
+
+  # "A2330751J"
+  out6401_A2330751J <- read_abs(cat_no = "6401.0", series_id = "A2330751J")
+  expect_equal(out6401_A2330751J, dplyr::filter(out6401_init, series_id == "A2330751J"))
+
+  # warning handling --- must be after out6401_next
+  expect_warning(read_abs(cat_no = "6401.0", series_id = "not a real series id"),
+                 regexp = "but was not present in the local table and will be ignored",
+                 fixed = TRUE)
+
+
+
+})
+
+
+
+

--- a/tests/testthat/test-fst.R
+++ b/tests/testthat/test-fst.R
@@ -29,6 +29,16 @@ test_that("read_abs works out of the box", {
 
 })
 
+test_that("fst-utils", {
+  expect_false(fst_available(cat_no = NULL))
+  expect_false(fst_available(cat_no = character(2)))
+  expect_false(fst_available(cat_no = NA_character_))
+  expect_false(fst_available(cat_no = ""))
+  tempf.fst <- tempfile(fileext = ".fst")
+  writeLines("9999-9", tempf.fst)
+  expect_false(fst_available("9999.9", path = dirname(tempf.fst)))
+})
+
 
 
 

--- a/tests/testthat/test-fst.R
+++ b/tests/testthat/test-fst.R
@@ -40,6 +40,7 @@ test_that("fst-utils", {
   tempf.fst <- tempfile(fileext = ".fst")
   writeLines("9999-9", tempf.fst)
   expect_false(fst_available("9999.9", path = dirname(tempf.fst)))
+  expect_equal(ext2ext("file.csv", ".txt"), "file.txt")
 })
 
 

--- a/tests/testthat/test-fst.R
+++ b/tests/testthat/test-fst.R
@@ -25,6 +25,9 @@ test_that("read_abs works out of the box", {
                  regexp = "but was not present in the local table and will be ignored",
                  fixed = TRUE)
 
+  expect_warning(read_abs(cat_no = "6401.0", tables = "not all"),
+                 regexp = "tables.*will be ignored")
+
 
 
 })

--- a/tests/testthat/test_readabs.R
+++ b/tests/testthat/test_readabs.R
@@ -190,9 +190,9 @@ test_that("read_abs() returns appropriate errors and messages when given invalid
 
   expect_error(read_abs(cat_no = NULL))
 
-  expect_error(read_abs("6202.0", 1, retain_files = NULL))
+  expect_error(read_abs("6202.0", 1, retain_files = NULL, check_local = FALSE))
 
-  expect_error(read_abs(cat_no = "6345.0", metadata = 1))
+  expect_error(read_abs(cat_no = "6345.0", metadata = 1, check_local = FALSE))
 
 })
 
@@ -202,7 +202,7 @@ test_that("read_abs() works with 'table 01' as well as 'table 1' filename struct
 
   check_abs_site()
 
-  const_df <- read_abs("8755.0", 1, retain_files = FALSE)
+  const_df <- read_abs("8755.0", 1, retain_files = FALSE, check_local = FALSE)
 
   expect_is(const_df, "data.frame")
 

--- a/tests/testthat/test_readabs.R
+++ b/tests/testthat/test_readabs.R
@@ -194,6 +194,10 @@ test_that("read_abs() returns appropriate errors and messages when given invalid
 
   expect_error(read_abs(cat_no = "6345.0", metadata = 1, check_local = FALSE))
 
+  expect_error(read_abs(cat_no = "6345.0", series_id = "foo", check_local = FALSE),
+               regexp = "either.*cat_no.*series_id")
+
+
 })
 
 test_that("read_abs() works with 'table 01' as well as 'table 1' filename structures",{

--- a/vignettes/readabs_vignette.Rmd
+++ b/vignettes/readabs_vignette.Rmd
@@ -233,13 +233,24 @@ If you already have ABS time series spreadsheets saved locally that you want to 
 
 If you just run `read_abs_local()` without any arguments specified, it will look in the directory given by the `R_READABS_PATH` environment variable (if set) and attempt to read any .xls files located there (note: it won't look in any of its subdirectories).
 
+In this vignette, the location of the files we've downloaded so far depend on whether 
+you have this environment variable set. To demonstrate `read_abs_local()` we'll need 
+to know the path in order to demonstrate how to use `read_abs_local()`
+
+
+```{r current_path}
+current_path <- Sys.getenv("R_READABS_PATH")
+if (!nzchar(current_path)) {
+  current_path <- tempdir()
+}
+```
+
 If you want to read all the files from a different directory, specify it using the `path` argument.
 
 If you've downloaded files using `read_abs()`, you can import them using `read_abs_local()` by specifying the catalogue number. This will look in the subdirectory of `path` that corresponds to `cat_no`:
 
 ```{r read-lfs-local-catno}
 lfs_local_1 <- read_abs_local("6202.0")
-
 ```
 
 If you want to read a particular table, or tables, you can specify them using the `filenames` argument. If your files are not in 
@@ -247,11 +258,8 @@ If you want to read a particular table, or tables, you can specify them using th
 you'll need to specify the directory using `path`, like this:
 
 ```{r read-lfs-local}
-# Ensure the path is available
-hutils::provide.dir(file.path(Sys.getenv("R_READABS_PATH", tempdir()), "6202.0"))
 lfs_local_2 <- read_abs_local(filenames = c("6202001.xls", "6202005.xls"),
-                              path = file.path(Sys.getenv("R_READABS_PATH", tempdir()), "6202.0"))
-
+                              path = file.path(current_path, "6202.0"))
 ```
 
 

--- a/vignettes/readabs_vignette.Rmd
+++ b/vignettes/readabs_vignette.Rmd
@@ -247,6 +247,8 @@ If you want to read a particular table, or tables, you can specify them using th
 you'll need to specify the directory using `path`, like this:
 
 ```{r read-lfs-local}
+# Ensure the path is available
+hutils::provide.dir(file.path(Sys.getenv("R_READABS_PATH", tempdir()), "6202.0"))
 lfs_local_2 <- read_abs_local(filenames = c("6202001.xls", "6202005.xls"),
                               path = file.path(Sys.getenv("R_READABS_PATH", tempdir()), "6202.0"))
 


### PR DESCRIPTION
Here is the initial commit of the fst-cache idea raised in #49 . 

Somethings I'm unsure about:

  1. What sort of metadata should be stored alongside the `fst` files? Currently, I've got a `.dcf` which seems to be normal for this sort of thing. I'm currently storing the MD5 and 'ProductReleaseDate' but both of these are currently not used for any purpose.
  2. Should the `fst` directory be a subset of `path` or of `path/cat_no`? Perhaps this doesn't matter (it may not even matter if we choose to change it). 
  3. General ergonomics. I've tested this out on "6202.0" and "6345.0" but I'm not sure how the package is actually being used out there so not sure if these are representative enough.


Note the build failure is a technical one. I will fix. 