### PR TITLE
Fix internet check

### DIFF
--- a/R/read_abs.R
+++ b/R/read_abs.R
@@ -156,9 +156,10 @@ read_abs <- function(cat_no = NULL,
       suppressWarnings(utils::download.file("https://www.abs.gov.au/robots.txt",
                            tmp, quiet = TRUE)),
       error = function(e) {
-        FALSE
+        return(FALSE)
       }
     )
+    TRUE
   }
 
   # Try nslookup. If this fails, try accessing abs.gov.au/robots.txt


### PR DESCRIPTION
@MattCowgill: I've rewritten the internet check which now works on split DNS networks.

The new method tries `curl::nslookup()` first. If this succeeds, then we keep the speed of the existing solution. However, if it fails, `readabs` tries to download https://www.abs.gov.au/robots.txt. If it still can't do this, it throws an error.