### PR TITLE
get all metadata, not just latest release

### DIFF
--- a/R/read_abs.R
+++ b/R/read_abs.R
@@ -198,7 +198,7 @@ read_abs <- function(cat_no = NULL,
 
   xml_dfs <- purrr::map_dfr(xml_urls,
                             .f = get_abs_xml_metadata,
-                            release_dates = "latest")
+                            release_dates = "all")
 
   # the same Series ID can appear in multiple spreadsheets;
   # we just want one (the latest)


### PR DESCRIPTION
closes https://github.com/MattCowgill/readabs/issues/65

Note: the ABS appears to have modified the Time Series Directory (without warning!) such that it now only contains metadata about the latest release.

Keeping release = "latest" means that `read_abs("6401.0", "all")` does not return all series, as they have released some extra tables in that catalogue number after the main release date. Switching to release = "all" could theoretically slow down the TSD query, but in practice does not because the ABS has removed old releases from the TSD.