### PR TITLE
get latest ProductIssue, not latest ReleaseDate

### DIFF
--- a/R/read_abs.R
+++ b/R/read_abs.R
@@ -198,7 +198,7 @@ read_abs <- function(cat_no = NULL,
 
   xml_dfs <- purrr::map_dfr(xml_urls,
                             .f = get_abs_xml_metadata,
-                            release_dates = "all")
+                            issue = "latest")
 
   # the same Series ID can appear in multiple spreadsheets;
   # we just want one (the latest)


### PR DESCRIPTION
fixes two issues:
1) in certain weird instances, `read_abs()` would fetch the latest and next-to-latest Excel file
2) occasionally, when data is updated or added after the initial product release, all tables in the same issue do not have the same release date