### PR TITLE
Remove label to remove errors

### DIFF
--- a/R/get_available_files.r
+++ b/R/get_available_files.r
@@ -64,11 +64,10 @@ get_available_files <- function(catalogue_string, refresh = FALSE) {
 
   # Find the url for the download
   available_downloads <- tibble::tibble(
-    label = download_page %>% rvest::html_nodes(".abs-data-download-left") %>% rvest::html_text(),
     url = download_page %>% rvest::html_nodes(".file a") %>% rvest::html_attr("href")
   ) %>%
     mutate(file = str_extract(url, "[^/]*$")) %>%
-    select(.data$label, .data$file, .data$url)
+    select(.data$file, .data$url)
 
   return(available_downloads)
 }

--- a/R/get_available_files.r
+++ b/R/get_available_files.r
@@ -63,11 +63,22 @@ get_available_files <- function(catalogue_string, refresh = FALSE) {
   )
 
   # Find the url for the download
-  available_downloads <- tibble::tibble(
-    url = download_page %>% rvest::html_nodes(".file a") %>% rvest::html_attr("href")
-  ) %>%
+  urls <- download_page %>% rvest::html_nodes(".file a") %>% rvest::html_attr("href")
+
+  labels <- download_page %>% rvest::html_nodes(".abs-data-download-left") %>% rvest::html_text()
+
+  #fix for some inconsistent CSS on ABS website
+  if(length(labels) != length(urls)) {labels <- download_page %>% rvest::html_nodes("h4") %>% rvest::html_text()}
+
+  #fix for anything that doesn't fit the above patterns
+
+  if(length(labels) != length(urls)) {labels <- rep(NA, length(urls))}
+
+
+  available_downloads <- tibble::tibble(url = urls,
+                                        label = labels) %>%
     mutate(file = str_extract(url, "[^/]*$")) %>%
-    select(.data$file, .data$url)
+    select(.data$label, .data$file, .data$url)
 
   return(available_downloads)
 }

--- a/tests/testthat/test-get_available_files.r
+++ b/tests/testthat/test-get_available_files.r
@@ -17,7 +17,6 @@ test_that("get_available_files() works", {
 
   error_names <- names(errors)
 
-  # Temporarily allow errors for catalogues that are known to not work
-  expect_lt(length(error_names), 9)
+  expect_equal(length(error_names), 0)
 
 })


### PR DESCRIPTION
Hi @MattCowgill  - this fixes those errors with get_available_files. 

EDIT: I've worked out how to keep the labels or at least NA if we can't find them.