### PR TITLE
Bug fix

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: readabs
 Type: Package
 Title: Download and Tidy Time Series Data from the Australian Bureau of Statistics
-Version: 0.4.5.1.901
+Version: 0.4.5.2
 Authors@R: c(
            person("Matt", "Cowgill", role = c("aut", "cre"), email = "mattcowgill@gmail.com"),
            person("Zoe", "Meers", role = "aut", email = "zoe.meers@sydney.edu.au"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,7 +11,7 @@ Authors@R: c(
 Maintainer: Matt Cowgill <mattcowgill@gmail.com>
 Description: Downloads, imports, and tidies time series data from the 
     Australian Bureau of Statistics <https://www.abs.gov.au/>.
-Date: 2020-09-16
+Date: 2020-11-06
 License: MIT + file LICENSE
 Encoding: UTF-8
 LazyData: true

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+# readabs 0.4.5.2
+* Bug fixes, including addressing a case where an ABS URL has a space in it
+
 # readabs 0.4.5.1
 * minor fixes to unit tests
 

--- a/R/read_abs.R
+++ b/R/read_abs.R
@@ -202,6 +202,8 @@ read_abs <- function(cat_no = NULL,
   }
 
   urls <- unique(xml_dfs$TableURL)
+  # Remove spaces from URLs
+  urls <- gsub(" ", "+", urls)
 
   table_titles <- unique(xml_dfs$TableTitle)
 

--- a/tests/testthat/test-readabs.R
+++ b/tests/testthat/test-readabs.R
@@ -10,6 +10,8 @@ check_abs_site <- function() {
 }
 
 test_that("read_abs() works for a series with a space in its URL", {
+  skip_if_offline()
+  skip_on_cran()
   # At time of test creation, ABS 8501.0 table 22 has a space in its URL:
   # https://www.abs.gov.au/statistics/industry/retail-and-wholesale-trade/retail-trade-australia/latest-release/table_23_online_retail_turnover_australia_by_type_of_activity_percentage_of_total_australian_retail turnover.xls
 

--- a/tests/testthat/test-readabs.R
+++ b/tests/testthat/test-readabs.R
@@ -9,6 +9,14 @@ check_abs_site <- function() {
   }
 }
 
+test_that("read_abs() works for a series with a space in its URL", {
+  # At time of test creation, ABS 8501.0 table 22 has a space in its URL:
+  # https://www.abs.gov.au/statistics/industry/retail-and-wholesale-trade/retail-trade-australia/latest-release/table_23_online_retail_turnover_australia_by_type_of_activity_percentage_of_total_australian_retail turnover.xls
+
+  t23_8501 <- read_abs(cat_no = "8501.0", tables = 23)
+})
+
+
 test_that("WPI XML page is a data.frame with expected column names", {
   skip_on_cran()
   check_abs_site()


### PR DESCRIPTION
The problem is on the ABS side (randomly including a space in a table URL, which causes `download.file()` to fail) but it's easily fixed here