### PR TITLE
Add `markdown` to `Suggests` in DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -38,5 +38,6 @@ VignetteBuilder: knitr
 Suggests: 
     knitr,
     rmarkdown,
+    markdown,
     testthat (>= 2.1.0),
     ggplot2


### PR DESCRIPTION
As per: https://github.com/yihui/knitr/issues/1864

`readabs` began failing `R CMD check` on GitHub Actions this morning, for the reason that `markdown` is not in `Suggests`. `markdown` is used to build the vignette. Until now, `rmarkdown` has been in `Suggests`, but the `markdown` dependency was not explicit.

This problem seems to be widespread - eg. `data.table`'s maintainers have made a similar fix: https://github.com/Rdatatable/data.table/pull/4954