### PR TITLE
Fix `read_payrolls()` again

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: readabs
 Type: Package
 Title: Download and Tidy Time Series Data from the Australian Bureau of Statistics
-Version: 0.4.10
+Version: 0.4.10.901
 Authors@R: c(
            person("Matt", "Cowgill", role = c("aut", "cre"), email = "mattcowgill@gmail.com", comment = c(ORCID = "0000-0003-0422-3300")),
            person("Zoe", "Meers", role = "aut", email = "zoe.meers@sydney.edu.au"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -31,7 +31,7 @@ Imports:
     rlang
 URL: https://github.com/mattcowgill/readabs
 BugReports: https://github.com/mattcowgill/readabs/issues
-RoxygenNote: 7.1.1
+RoxygenNote: 7.1.2
 VignetteBuilder: knitr
 Suggests: 
     knitr,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+# readabs 0.4.10.900
+* New options available in read_payrolls()
+
 # readabs 0.4.10
 * "industry_wages" is no longer an option in read_payrolls() as it has been removed from the data
 * Bug fixes

--- a/R/read_payrolls.R
+++ b/R/read_payrolls.R
@@ -24,7 +24,8 @@
 #'  \item{"empsize_jobs"}{ Payroll jobs by size of employer (number of
 #'  employees) and state (Table 7)}
 #'  \item{"gccsa_jobs"}{ Payroll jobs by Greater Capital City Statistical
-#'  Area (Table)}
+#'  Area (Table 5)}
+#'  \item{"sex_age_jobs}{ Payroll jobs by sex and age (Table 8)}
 #' }
 #' The default is "industry_jobs".
 #' @return A tidy (long) `tbl_df`. The number of columns differs based on the `series`.

--- a/R/read_payrolls.R
+++ b/R/read_payrolls.R
@@ -23,6 +23,8 @@
 #'  industry division (Table 6)}
 #'  \item{"empsize_jobs"}{ Payroll jobs by size of employer (number of
 #'  employees) and state (Table 7)}
+#'  \item{"gccsa_jobs"}{ Payroll jobs by Greater Capital City Statistical
+#'  Area (Table)}
 #' }
 #' The default is "industry_jobs".
 #' @return A tidy (long) `tbl_df`. The number of columns differs based on the `series`.
@@ -50,7 +52,8 @@ read_payrolls <- function(series = c(
                             "sa4_jobs",
                             "sa3_jobs",
                             "subindustry_jobs",
-                            "empsize_jobs"
+                            "empsize_jobs",
+                            "gccsa_jobs"
                           ),
                           path = Sys.getenv("R_READABS_PATH",
                             unset = tempdir()
@@ -64,7 +67,8 @@ read_payrolls <- function(series = c(
     "sa4_jobs" = "DO005",
     "sa3_jobs" = "DO005",
     "subindustry_jobs" = "DO006",
-    "empsize_jobs" = "DO007"
+    "empsize_jobs" = "DO007",
+    "gccsa_jobs" = "DO005"
   )
 
   safely_download_cube <- purrr::safely(.f = ~ download_abs_data_cube(
@@ -97,10 +101,11 @@ read_payrolls <- function(series = c(
 
   sheet_name <- switch(series,
     "industry_jobs" = "Payroll jobs index",
-    "sa4_jobs" = "Payroll jobs index-SA4",
-    "sa3_jobs" = "Payroll jobs index-SA3",
+    "sa4_jobs" = "SA4",
+    "sa3_jobs" = "SA3",
     "subindustry_jobs" = "Payroll jobs index-Subdivision",
-    "empsize_jobs" = "Employment size"
+    "empsize_jobs" = "Employment size",
+    "gccsa_jobs" = "GCCSA"
   )
 
   cube <- read_payrolls_local(

--- a/R/read_payrolls.R
+++ b/R/read_payrolls.R
@@ -53,7 +53,8 @@ read_payrolls <- function(series = c(
                             "sa3_jobs",
                             "subindustry_jobs",
                             "empsize_jobs",
-                            "gccsa_jobs"
+                            "gccsa_jobs",
+                            "sex_age_jobs"
                           ),
                           path = Sys.getenv("R_READABS_PATH",
                             unset = tempdir()
@@ -68,7 +69,8 @@ read_payrolls <- function(series = c(
     "sa3_jobs" = "DO005",
     "subindustry_jobs" = "DO006",
     "empsize_jobs" = "DO007",
-    "gccsa_jobs" = "DO005"
+    "gccsa_jobs" = "DO005",
+    "sex_age_jobs" = "DO008"
   )
 
   safely_download_cube <- purrr::safely(.f = ~ download_abs_data_cube(
@@ -105,7 +107,8 @@ read_payrolls <- function(series = c(
     "sa3_jobs" = "SA3",
     "subindustry_jobs" = "Payroll jobs index-Subdivision",
     "empsize_jobs" = "Employment size",
-    "gccsa_jobs" = "GCCSA"
+    "gccsa_jobs" = "GCCSA",
+    "sex_age_jobs" = "5 year age groups"
   )
 
   cube <- read_payrolls_local(

--- a/man/read_payrolls.Rd
+++ b/man/read_payrolls.Rd
@@ -6,7 +6,7 @@
 \usage{
 read_payrolls(
   series = c("industry_jobs", "sa4_jobs", "sa3_jobs", "subindustry_jobs",
-    "empsize_jobs"),
+    "empsize_jobs", "gccsa_jobs"),
   path = Sys.getenv("R_READABS_PATH", unset = tempdir())
 )
 }
@@ -22,6 +22,8 @@ read_payrolls(
  industry division (Table 6)}
  \item{"empsize_jobs"}{ Payroll jobs by size of employer (number of
  employees) and state (Table 7)}
+ \item{"gccsa_jobs"}{ Payroll jobs by Greater Capital City Statistical
+ Area (Table)}
 }
 The default is "industry_jobs".}
 

--- a/man/read_payrolls.Rd
+++ b/man/read_payrolls.Rd
@@ -6,7 +6,7 @@
 \usage{
 read_payrolls(
   series = c("industry_jobs", "sa4_jobs", "sa3_jobs", "subindustry_jobs",
-    "empsize_jobs", "gccsa_jobs"),
+    "empsize_jobs", "gccsa_jobs", "sex_age_jobs"),
   path = Sys.getenv("R_READABS_PATH", unset = tempdir())
 )
 }
@@ -23,7 +23,8 @@ read_payrolls(
  \item{"empsize_jobs"}{ Payroll jobs by size of employer (number of
  employees) and state (Table 7)}
  \item{"gccsa_jobs"}{ Payroll jobs by Greater Capital City Statistical
- Area (Table)}
+ Area (Table 5)}
+ \item{"sex_age_jobs}{ Payroll jobs by sex and age (Table 8)}
 }
 The default is "industry_jobs".}
 

--- a/tests/testthat/test-read_payrolls.R
+++ b/tests/testthat/test-read_payrolls.R
@@ -19,7 +19,8 @@ test_that("read_payrolls() works", {
       "sa4_jobs",
       "sa3_jobs",
       "subindustry_jobs",
-      "empsize_jobs"
+      "empsize_jobs",
+      "gccsa_jobs"
     ),
     ~ check_payrolls(.x)
   )


### PR DESCRIPTION
The ABS changed the names of the sheets in the Excel files for the Weekly Payroll jobs release. This breaks `read_payrolls()`. This PR fixes the issue.