### PR TITLE
Updated to accommodate change in ABS naming convention

### DIFF
--- a/R/extract_abs_sheets.R
+++ b/R/extract_abs_sheets.R
@@ -30,7 +30,7 @@ extract_abs_sheets <- function(filename,
   filename <- file.path(path, filename)
 
   sheets <- readxl::excel_sheets(path = filename)
-  sheets <- sheets[!sheets %in% c("Index", "Inquiries")]
+  sheets <- sheets[!sheets %in% c("Index", "Inquiries", "Enquiries")]
 
   if (length(sheets) < 1) {
     stop(sprintf(


### PR DESCRIPTION
The [latest labour force data](https://www.abs.gov.au/statistics/labour/employment-and-unemployment/labour-force-australia/latest-release) changed the "Inquiries" sheet to "Enquiries". Can cause unintentional parse of non-data sheet