### PR TITLE
Allow users to fetch previous vintage of time series

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: readabs
 Type: Package
 Title: Download and Tidy Time Series Data from the Australian Bureau of Statistics
-Version: 0.4.12.905
+Version: 0.4.12.906
 Authors@R: c(
            person("Matt", "Cowgill", role = c("aut", "cre"), email = "mattcowgill@gmail.com", comment = c(ORCID = "0000-0003-0422-3300")),
            person("Zoe", "Meers", role = "aut", email = "zoe.meers@sydney.edu.au"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # readabs 0.4.12.90x
 * Added read_job_mobility()
+* Added a `release_date` argument to `read_abs()`
 * Bug fixes
 
 # readabs 0.4.12

--- a/R/check_abs_connection.R
+++ b/R/check_abs_connection.R
@@ -14,7 +14,6 @@
 #' @noRd
 
 check_abs_connection <- function() {
-
   abs_url_works <- url_exists("https://www.abs.gov.au")
 
 
@@ -27,7 +26,6 @@ check_abs_connection <- function() {
         " Please check your internet connection and security settings."
       )
     }
-
   }
 
   invisible(TRUE)
@@ -41,32 +39,29 @@ check_abs_connection <- function() {
 #' @noRd
 
 url_exists <- function(url = "https://www.abs.gov.au") {
+  sHEAD <- purrr::safely(httr::HEAD)
+  sGET <- purrr::safely(httr::GET)
 
-    sHEAD <- purrr::safely(httr::HEAD)
-    sGET <- purrr::safely(httr::GET)
+  # Try HEAD first since it's lightweight
+  res <- sHEAD(url)
 
-    # Try HEAD first since it's lightweight
-    res <- sHEAD(url)
+  if (is.null(res$result) ||
+    ((httr::status_code(res$result) %/% 200) != 1)) {
+    res <- sGET(url)
 
-    if (is.null(res$result) ||
-        ((httr::status_code(res$result) %/% 200) != 1)) {
-
-      res <- sGET(url)
-
-      if (is.null(res$result)) return(FALSE)
-
-      if (((httr::status_code(res$result) %/% 200) != 1)) {
-        warning(sprintf("[%s] appears to be online but isn't responding as expected; HTTP status code is not in the 200-299 range", url))
-        return(FALSE)
-
-      }
-
-      return(TRUE)
-
-    } else {
-      return(TRUE)
+    if (is.null(res$result)) {
+      return(FALSE)
     }
 
+    if (((httr::status_code(res$result) %/% 200) != 1)) {
+      warning(sprintf("[%s] appears to be online but isn't responding as expected; HTTP status code is not in the 200-299 range", url))
+      return(FALSE)
+    }
+
+    return(TRUE)
+  } else {
+    return(TRUE)
+  }
 }
 
 #' Internal function to check if URL exists. Slower than url_exists. Used

--- a/R/check_latest_date.R
+++ b/R/check_latest_date.R
@@ -66,9 +66,9 @@ check_latest_date <- function(cat_no = NULL,
   # (it'll be the oldest in the directory)
 
   max_date <- as.Date(xml_df$SeriesEnd,
-                      format = "%d/%m/%Y") %>%
-                    max()
+    format = "%d/%m/%Y"
+  ) %>%
+    max()
 
   max_date
-
 }

--- a/R/download_abs.R
+++ b/R/download_abs.R
@@ -35,3 +35,5 @@ dl_file <- function(url, destfile, quiet = TRUE) {
     cacheOK = FALSE
   )
 }
+
+safely_download_abs <- purrr::safely(download_abs)

--- a/R/download_abs.R
+++ b/R/download_abs.R
@@ -12,27 +12,26 @@ download_abs <- function(urls,
 
   filenames <- file.path(path, basename(urls))
 
-  purrr::walk2(.x = urls,
-               .y = filenames,
-               .f = dl_file,
-               quiet = !show_progress_bars)
+  purrr::walk2(
+    .x = urls,
+    .y = filenames,
+    .f = dl_file,
+    quiet = !show_progress_bars
+  )
 
   return(TRUE)
 }
 
 dl_file <- function(url, destfile, quiet = TRUE) {
-
-  if (isFALSE(quiet)) {
-    message("Downloading ", url)
-  }
-
-  utils::download.file(
-    url = url,
-    destfile = destfile,
-    mode = "wb",
-    quiet = quiet,
-    headers = readabs_header,
-    cacheOK = FALSE
+  suppressWarnings(
+    utils::download.file(
+      url = url,
+      destfile = destfile,
+      mode = "wb",
+      quiet = quiet,
+      headers = readabs_header,
+      cacheOK = FALSE
+    )
   )
 }
 

--- a/R/download_data_cube.r
+++ b/R/download_data_cube.r
@@ -22,7 +22,6 @@
 #'  See \code{Details} below for  more information.
 #'
 #' @examples
-#'
 #' \dontrun{
 #' download_abs_data_cube(
 #'   catalogue_string = "labour-force-australia-detailed",
@@ -89,8 +88,10 @@ download_abs_data_cube <- function(catalogue_string,
 
   # download file
 
-  dl_file(file_download_url,
-          filepath)
+  dl_file(
+    file_download_url,
+    filepath
+  )
 
   message("File downloaded in ", filepath)
 

--- a/R/extract_abs_sheets.R
+++ b/R/extract_abs_sheets.R
@@ -25,13 +25,13 @@ extract_abs_sheets <- function(filename,
                                path = Sys.getenv("R_READABS_PATH",
                                  unset = tempdir()
                                )) {
-
-
   filename <- file.path(path, filename)
 
   sheets <- readxl::excel_sheets(path = filename)
-  sheets <- sheets[!sheets %in% c("Index", "Inquiries", "Enquiries",
-                                  "Contents")]
+  sheets <- sheets[!sheets %in% c(
+    "Index", "Inquiries", "Enquiries",
+    "Contents"
+  )]
   sheets <- sheets[!grepl("Table ", sheets, ignore.case = T)]
 
   if (length(sheets) < 1) {

--- a/R/get_abs_xml_metadata.R
+++ b/R/get_abs_xml_metadata.R
@@ -13,11 +13,12 @@ get_abs_xml_metadata <- function(url) {
   first_page_df <- get_first_xml_page(url)
 
   get_numpages <- function(url) {
-
     temp_xml <- tempfile(fileext = ".xml")
 
-    dl_file(url = url,
-            destfile = temp_xml)
+    dl_file(
+      url = url,
+      destfile = temp_xml
+    )
 
     temp_xml %>%
       xml2::read_xml() %>%

--- a/R/get_xml_dfs.R
+++ b/R/get_xml_dfs.R
@@ -4,13 +4,18 @@
 #' @importFrom dplyr filter select "%>%"
 
 get_xml_dfs <- function(urls) {
+  xml_files <- tempfile(
+    pattern = as.character(seq_along(urls)),
+    fileext = ".xml"
+  )
 
-  xml_files <- tempfile(pattern = as.character(seq_along(urls)),
-                        fileext = ".xml")
-
-  purrr::walk2(urls, xml_files,
-               ~dl_file(url = .x,
-                        destfile = .y))
+  purrr::walk2(
+    urls, xml_files,
+    ~ dl_file(
+      url = .x,
+      destfile = .y
+    )
+  )
 
   xml_to_df <- function(file) {
     xml_series <- file %>%
@@ -26,9 +31,8 @@ get_xml_dfs <- function(urls) {
 
     child_list %>%
       purrr::map(xml2::xml_text) %>%
-      purrr::map_dfr(.f = ~purrr::set_names(.x, xml_names))
+      purrr::map_dfr(.f = ~ purrr::set_names(.x, xml_names))
   }
 
   purrr::map_dfr(xml_files, xml_to_df)
-
 }

--- a/R/read_abs.R
+++ b/R/read_abs.R
@@ -187,6 +187,10 @@ read_abs <- function(cat_no = NULL,
     stop("`metadata` argument must be either TRUE or FALSE")
   }
 
+  if (length(release_date) != 1) {
+    stop("`release_date` argument must be length 1.")
+  }
+
   # satisfy CRAN
   ProductReleaseDate <- SeriesID <- NULL
 
@@ -289,7 +293,6 @@ read_abs <- function(cat_no = NULL,
       stop("URL ", url, " does not appear to be valid.")
     }
   }
-
 
   # extract the sheets to a list
   filenames <- base::basename(urls)

--- a/R/read_abs.R
+++ b/R/read_abs.R
@@ -43,7 +43,7 @@
 #' @param release_date Either `"latest"` or a string coercible to a date, such as
 #' `"2022-02-01"`. If `"latest"`, the latest release of the requested data will
 #' be returned. If a date, (eg. `"2022-02-01"`) `read_abs()` will
-#' attempt to download the data from that month's release.
+#' attempt to download the data from that month's release. See `Details`.
 #'
 #' @return A data frame (tibble) containing the tidied data from the ABS time
 #' series table(s).
@@ -65,6 +65,13 @@
 #' If you would like to change this variable for all future R sessions, edit
 #' your `.Renviron` file and add \code{R_READABS_PATH = <path>} line.
 #' The easiest way to edit this file is using \code{usethis::edit_r_environ()}.
+#'
+#' The `release_date` argument allows you to download table(s) other than the
+#' latest release. This is useful for examining revisions to time series, or
+#' for obtaining the version of series that were available on a given date.
+#' Note that you cannot supply more than one date to `release_date`. Note also
+#' that any dates prior to mid-2019 (the exact date varies by series) will fail.
+#'
 #' @rdname read_abs
 #' @examples
 #'
@@ -114,7 +121,6 @@ read_abs <- function(cat_no = NULL,
                      retain_files = TRUE,
                      check_local = TRUE,
                      release_date = "latest") {
-
   if (isTRUE(check_local) &&
     fst_available(cat_no = cat_no, path = path)) {
     if (!identical(tables, "all")) {
@@ -208,10 +214,10 @@ read_abs <- function(cat_no = NULL,
     series_id = series_id
   )
 
-
   # find spreadsheet URLs from cat_no in the Time Series Directory
-  download_message <- ifelse(!is.null(cat_no), paste0("catalogue ", cat_no),
-    "series ID "
+  download_message <- ifelse(!is.null(cat_no),
+    paste0("catalogue ", cat_no),
+    paste0("series ID", series_id)
   )
 
   message(paste0(
@@ -249,9 +255,12 @@ read_abs <- function(cat_no = NULL,
   urls <- gsub(" ", "+", urls)
 
   if (release_date != "latest") {
-    urls <- gsub("latest-release",
-         tolower(format(as.Date(release_date), "%b-%Y")),
-         urls)
+    requested_date <- format(as.Date(release_date), "%b-%Y")
+    urls <- gsub(
+      "latest-release",
+      tolower(requested_date),
+      urls
+    )
   }
 
   table_titles <- unique(xml_dfs$TableTitle)
@@ -276,9 +285,8 @@ read_abs <- function(cat_no = NULL,
       show_progress_bars = show_progress_bars
     )
 
-    stopifnot(is.null(dl_result_xls$error))
     if (!is.null(dl_result_xls$error)) {
-      stop(dl_result$error)
+      stop("URL ", url, " does not appear to be valid.")
     }
   }
 
@@ -335,17 +343,21 @@ read_abs <- function(cat_no = NULL,
 #' @export
 
 read_abs_series <- function(series_id, ...) {
-  read_abs(series_id = series_id,
-           ...)
+  read_abs(
+    series_id = series_id,
+    ...
+  )
 }
 
 match_tables <- function(table_list, requested_tables) {
   requested <- paste0(requested_tables, collapse = "|")
   # Looking for table number preceded by a space or a 0, and
   # followed my a full stop or a space
-  regex_pattern <- paste0("(?<=\\s|0)",
-                          "(", requested, ")",
-                          "(?=\\.|\\s|\\:)")
+  regex_pattern <- paste0(
+    "(?<=\\s|0)",
+    "(", requested, ")",
+    "(?=\\.|\\s|\\:)"
+  )
 
   predot_matches <- regexpr(".*\\.|.*\\:", table_list)
   table_list_predot <- regmatches(table_list, m = predot_matches)

--- a/R/read_awe.R
+++ b/R/read_awe.R
@@ -39,29 +39,36 @@
 #' }
 #'
 #' @export
-read_awe <- function(wage_measure = c("awote",
-                                      "ftawe",
-                                      "awe"),
-                     sex = c("persons",
-                             "males",
-                             "females"),
-                     sector = c("total",
-                                "private",
-                                "public"),
-                     state = c("all",
-                               "nsw",
-                               "vic",
-                               "qld",
-                               "sa",
-                               "wa",
-                               "tas",
-                               "nt",
-                               "act"),
+read_awe <- function(wage_measure = c(
+                       "awote",
+                       "ftawe",
+                       "awe"
+                     ),
+                     sex = c(
+                       "persons",
+                       "males",
+                       "females"
+                     ),
+                     sector = c(
+                       "total",
+                       "private",
+                       "public"
+                     ),
+                     state = c(
+                       "all",
+                       "nsw",
+                       "vic",
+                       "qld",
+                       "sa",
+                       "wa",
+                       "tas",
+                       "nt",
+                       "act"
+                     ),
                      na.rm = FALSE,
                      path = Sys.getenv("R_READABS_PATH", unset = tempdir()),
                      show_progress_bars = FALSE,
                      check_local = FALSE) {
-
   .wage_measure <- match.arg(wage_measure)
   .sex <- match.arg(sex)
   .sector <- match.arg(sector)
@@ -70,16 +77,18 @@ read_awe <- function(wage_measure = c("awote",
   check_abs_connection()
 
   if (.sector != "total" &
-      .state != "all") {
-    stop('You cannot get sector-by-state data. Either set sector to "total"',
-         ' or state to "all".')
+    .state != "all") {
+    stop(
+      'You cannot get sector-by-state data. Either set sector to "total"',
+      ' or state to "all".'
+    )
   }
 
   if (.state == "all") {
-    tables <- switch (.sector,
-                      "total" = "2",
-                      "private" = "5",
-                      "public" = "8"
+    tables <- switch(.sector,
+      "total" = "2",
+      "private" = "5",
+      "public" = "8"
     )
 
     if (.sector == "total") {
@@ -87,26 +96,28 @@ read_awe <- function(wage_measure = c("awote",
     } else {
       crosstab_name <- "sector"
     }
-
   } else {
-    tables <- switch (.state,
-                      "nsw" = "12a",
-                      "vic" = "12b",
-                      "qld" = "12c",
-                      "sa" = "12d",
-                      "wa" = "12e",
-                      "tas" = "12f",
-                      "nt" = "12g",
-                      "act" = "12h")
+    tables <- switch(.state,
+      "nsw" = "12a",
+      "vic" = "12b",
+      "qld" = "12c",
+      "sa" = "12d",
+      "wa" = "12e",
+      "tas" = "12f",
+      "nt" = "12g",
+      "act" = "12h"
+    )
 
     crosstab_name <- "state"
   }
 
-  awe_latest <- suppressMessages(read_abs(cat_no = "6302.0",
-                                          tables = tables,
-                                          path = path,
-                                          show_progress_bars = show_progress_bars,
-                                          check_local = check_local))
+  awe_latest <- suppressMessages(read_abs(
+    cat_no = "6302.0",
+    tables = tables,
+    path = path,
+    show_progress_bars = show_progress_bars,
+    check_local = check_local
+  ))
 
   awe_latest <- tidy_awe(df = awe_latest)
 
@@ -119,24 +130,29 @@ read_awe <- function(wage_measure = c("awote",
   awe <- dplyr::bind_rows(awe_old_table, awe_latest)
 
   awe <- awe %>%
-    filter(.data$sex == .sex,
-           .data$wage_measure == .wage_measure)
+    filter(
+      .data$sex == .sex,
+      .data$wage_measure == .wage_measure
+    )
 
   if (isFALSE(na.rm)) {
     # Pad to ensure data is quarterly
-    missing_dates <- expand.grid(month = unique(format(awe$date, "%m")),
-                year = unique(format(awe$date, "%Y")),
-                day = 15,
-                sex = .sex,
-                wage_measure = .wage_measure,
-                stringsAsFactors = FALSE) %>%
+    missing_dates <- expand.grid(
+      month = unique(format(awe$date, "%m")),
+      year = unique(format(awe$date, "%Y")),
+      day = 15,
+      sex = .sex,
+      wage_measure = .wage_measure,
+      stringsAsFactors = FALSE
+    ) %>%
       dplyr::mutate(date = as.Date(paste(.data$year,
-                                         .data$month,
-                                         .data$day,
-                                         sep = "-"))) %>%
+        .data$month,
+        .data$day,
+        sep = "-"
+      ))) %>%
       dplyr::filter(!date %in% awe$date &
-                      date > min(awe$date) &
-                      date < max(awe$date)) %>%
+        date > min(awe$date) &
+        date < max(awe$date)) %>%
       mutate(value = NA_real_) %>%
       dplyr::select(dplyr::any_of(c("date", "sex", "wage_measure", "value", "crosstab")))
 
@@ -156,14 +172,16 @@ read_awe <- function(wage_measure = c("awote",
 
   if (!is.null(awe[["state"]])) {
     awe <- awe %>%
-      dplyr::mutate(state = dplyr::case_when(state == "new south wales" ~ "nsw",
-                                             state == "victoria" ~ "vic",
-                                             state == "queensland" ~ "qld",
-                                             state == "south australia" ~ "sa",
-                                             state == "western australia" ~ "wa",
-                                             state == "tasmania" ~ "tas",
-                                             state == "northern territory" ~ "nt",
-                                             state == "australian capital territory" ~ "act"))
+      dplyr::mutate(state = dplyr::case_when(
+        state == "new south wales" ~ "nsw",
+        state == "victoria" ~ "vic",
+        state == "queensland" ~ "qld",
+        state == "south australia" ~ "sa",
+        state == "western australia" ~ "wa",
+        state == "tasmania" ~ "tas",
+        state == "northern territory" ~ "nt",
+        state == "australian capital territory" ~ "act"
+      ))
   }
 
   awe <- awe %>%
@@ -177,59 +195,69 @@ read_awe <- function(wage_measure = c("awote",
 #' @param df Data frame containing table 2 from ABS 6302, imported using `read_abs()`
 #' @keywords internal
 tidy_awe <- function(df) {
-
   df <- df %>%
     dplyr::select(.data$series, .data$date, .data$value)
 
   df <- df %>%
-    dplyr::mutate(series = fast_str_squish(.data$series),
-                  series = stringi::stri_replace_all_fixed(.data$series, " ;", ";"))
+    dplyr::mutate(
+      series = fast_str_squish(.data$series),
+      series = stringi::stri_replace_all_fixed(.data$series, " ;", ";")
+    )
 
   # Usually the cross tab (eg. state, sector) is at the end of the series string;
   # For fun, sometimes the ABS puts it as the second element!
   df <- df %>%
     tidyr::separate(.data$series,
-             into = c("earnse_crosstab1", "series"),
-             sep = "(?=Males|Females|Persons;)",
-             extra = "merge",
-             fill = "right")
+      into = c("earnse_crosstab1", "series"),
+      sep = "(?=Males|Females|Persons;)",
+      extra = "merge",
+      fill = "right"
+    )
 
   df <- df %>%
     tidyr::separate(.data$earnse_crosstab1,
-             into = c("earnse", "crosstab1"),
-             sep = ";",
-             extra = "merge",
-             fill = "right")
+      into = c("earnse", "crosstab1"),
+      sep = ";",
+      extra = "merge",
+      fill = "right"
+    )
 
   df <- df %>%
     tidyr::separate(.data$series,
-                    into = c("sex_measure",
-                             "crosstab2"),
-                    sep = "earnings;",
-                    extra = "merge",
-                    fill = "right")
+      into = c(
+        "sex_measure",
+        "crosstab2"
+      ),
+      sep = "earnings;",
+      extra = "merge",
+      fill = "right"
+    )
 
   df <- df %>%
-    dplyr::mutate(crosstab = paste0(.data$crosstab1, .data$crosstab2),
-                  crosstab = fast_str_squish(.data$crosstab),
-                  crosstab = dplyr::if_else(.data$crosstab == "",
-                                     NA_character_,
-                                     .data$crosstab))
+    dplyr::mutate(
+      crosstab = paste0(.data$crosstab1, .data$crosstab2),
+      crosstab = fast_str_squish(.data$crosstab),
+      crosstab = dplyr::if_else(.data$crosstab == "",
+        NA_character_,
+        .data$crosstab
+      )
+    )
 
   df <- df %>%
     mutate(crosstab = stringi::stri_replace_all_fixed(.data$crosstab, " sector", ""))
 
   df <- df %>%
     # Drop the crosstab column if it's full of NAs
-    dplyr::select_if(~all(!is.na(.))) %>%
+    dplyr::select_if(~ all(!is.na(.))) %>%
     dplyr::select(-.data$crosstab1, -.data$crosstab2)
 
   df <- df %>%
     tidyr::separate(.data$sex_measure,
-                    into = c("sex", "measure"),
-                    sep = ";",
-                    extra = "merge",
-                    fill = "right")
+      into = c("sex", "measure"),
+      sep = ";",
+      extra = "merge",
+      fill = "right"
+    )
 
   fix_col <- function(col) {
     col <- gsub(";", "", col, fixed = TRUE)
@@ -256,7 +284,8 @@ tidy_awe <- function(df) {
         .data$measure == "full time adult total" ~ "ftawe",
         .data$measure == "total" ~ "awe",
         TRUE ~ NA_character_
-      ))
+      )
+    )
 
   df <- df %>%
     dplyr::select(dplyr::any_of(c("date", "sex", "wage_measure", "value", "crosstab")))

--- a/R/read_job_mobility.R
+++ b/R/read_job_mobility.R
@@ -16,7 +16,8 @@
 #'
 read_job_mobility <- function(tables = "all",
                               path = Sys.getenv("R_READABS_PATH",
-                                                unset = tempdir())) {
+                                unset = tempdir()
+                              )) {
   check_abs_connection()
 
   available_tables <- show_available_files("job-mobility") %>%
@@ -26,8 +27,10 @@ read_job_mobility <- function(tables = "all",
     selected_tables <- available_tables
   } else {
     selected_tables <- available_tables %>%
-      dplyr::filter(grepl(paste0(tables, collapse = "|"),
-                          label))
+      dplyr::filter(grepl(
+        paste0(tables, collapse = "|"),
+        label
+      ))
   }
 
   cubes <- selected_tables$file
@@ -38,9 +41,10 @@ read_job_mobility <- function(tables = "all",
     )
 
   cube_results <- purrr::map(cubes,
-                            safely_download_cube,
-                            catalogue_string = "job-mobility",
-                            path = path)
+    safely_download_cube,
+    catalogue_string = "job-mobility",
+    path = path
+  )
 
   cube_results <- purrr::set_names(cube_results, cubes)
 
@@ -52,11 +56,12 @@ read_job_mobility <- function(tables = "all",
     result_list$result
   }
 
-  cube_paths <- purrr::map2_chr(cube_results,
-                                cubes,
-                                get_result)
+  cube_paths <- purrr::map2_chr(
+    cube_results,
+    cubes,
+    get_result
+  )
 
 
   read_abs_local(filenames = cube_paths)
-
 }

--- a/R/read_lfs_grossflows.R
+++ b/R/read_lfs_grossflows.R
@@ -20,53 +20,64 @@
 #' \dontrun{
 #' read_lfs_grossflows()
 #' }
-
-
-read_lfs_grossflows <- function(weights = c("current",
-                                           "previous"),
+#'
+read_lfs_grossflows <- function(weights = c(
+                                  "current",
+                                  "previous"
+                                ),
                                 path = Sys.getenv("R_READABS_PATH",
-                                                  unset = tempdir())) {
-
+                                  unset = tempdir()
+                                )) {
   weights <- match.arg(weights)
 
-  weight_desc <- switch (weights,
+  weight_desc <- switch(weights,
     "current" = "current month",
     "previous" = "previous month"
   )
 
-  gf_file <- download_abs_data_cube(catalogue_string = "labour-force-australia",
-                                    cube = "gm1",
-                                    path = path)
+  gf_file <- download_abs_data_cube(
+    catalogue_string = "labour-force-australia",
+    cube = "gm1",
+    path = path
+  )
 
-  sheet_name <- switch (weights,
+  sheet_name <- switch(weights,
     "current" = "Data 1",
     "previous" = "Data 2"
   )
 
-  raw_sheet <- readxl::read_xlsx(path = gf_file,
-                                 sheet = sheet_name,
-                                 skip = 4,
-                                 col_names = c("date",
-                                               "sex",
-                                               "age",
-                                               "state",
-                                               "lfs_current",
-                                               "lfs_previous",
-                                               "persons"),
-                                 col_types = c("date",
-                                               "text",
-                                               "text",
-                                               "text",
-                                               "text",
-                                               "text",
-                                               "numeric"
-                                               ))
+  raw_sheet <- readxl::read_xlsx(
+    path = gf_file,
+    sheet = sheet_name,
+    skip = 4,
+    col_names = c(
+      "date",
+      "sex",
+      "age",
+      "state",
+      "lfs_current",
+      "lfs_previous",
+      "persons"
+    ),
+    col_types = c(
+      "date",
+      "text",
+      "text",
+      "text",
+      "text",
+      "text",
+      "numeric"
+    )
+  )
 
   gf <- raw_sheet %>%
-    mutate(date = as.Date(date,
-                          format = "%Y-%m-%d %H-%M-%S"),
-           unit = "000s",
-           weights = weight_desc)
+    mutate(
+      date = as.Date(date,
+        format = "%Y-%m-%d %H-%M-%S"
+      ),
+      unit = "000s",
+      weights = weight_desc
+    )
 
   # Run some minimal checks on the data frame to ensure its contents are as
   # expected
@@ -80,45 +91,62 @@ read_lfs_grossflows <- function(weights = c("current",
 #' @param df data frame containing gross flows data
 #' @keywords internal
 check_lfs_grossflows <- function(df) {
+  names_match <- identical(
+    names(df),
+    c(
+      "date",
+      "sex",
+      "age",
+      "state",
+      "lfs_current",
+      "lfs_previous",
+      "persons",
+      "unit",
+      "weights"
+    )
+  )
 
-  names_match <- identical(names(df),
-                           c("date",
-                             "sex",
-                             "age",
-                             "state",
-                             "lfs_current",
-                             "lfs_previous",
-                             "persons",
-                             "unit",
-                             "weights"))
+  sex_match <- identical(
+    unique(df$sex),
+    c(
+      "Males",
+      "Females"
+    )
+  )
 
-  sex_match <- identical(unique(df$sex),
-                         c("Males",
-                           "Females"))
+  age_match <- identical(
+    unique(df$age),
+    c(
+      "15-19 years",
+      "20-24 years",
+      "25-29 years",
+      "30-34 years",
+      "35-39 years",
+      "40-44 years",
+      "45-49 years",
+      "50-54 years",
+      "55-59 years",
+      "60-64 years",
+      "65 years and over"
+    )
+  )
 
-  age_match <- identical(unique(df$age),
-                         c("15-19 years",
-                            "20-24 years",
-                            "25-29 years",
-                            "30-34 years",
-                            "35-39 years",
-                            "40-44 years",
-                            "45-49 years",
-                            "50-54 years",
-                            "55-59 years",
-                            "60-64 years",
-                            "65 years and over"))
+  lfs_match <- identical(
+    unique(df$lfs_current),
+    c(
+      "Employed full-time",
+      "Employed part-time",
+      "Unemployed",
+      "Not in the labour force (NILF)",
+      "Unmatched in common sample (responded in previous month but not in current)",
+      "Outgoing rotation group"
+    )
+  )
 
-  lfs_match <- identical(unique(df$lfs_current),
-                         c("Employed full-time",
-                            "Employed part-time",
-                            "Unemployed",
-                            "Not in the labour force (NILF)",
-                            "Unmatched in common sample (responded in previous month but not in current)",
-                            "Outgoing rotation group"))
-
-  all(names_match,
-      sex_match,
-      age_match,
-      lfs_match)
+  all(
+    names_match,
+    sex_match,
+    age_match,
+    lfs_match
+  )
 }

--- a/R/scrape_abs_catalogues.r
+++ b/R/scrape_abs_catalogues.r
@@ -17,8 +17,10 @@ scrape_abs_catalogues <- function() {
 
   # Scrape the main ABS statistics page
   stats_page_file <- tempfile(fileext = ".html")
-  dl_file(url = "https://www.abs.gov.au/statistics",
-          destfile = stats_page_file)
+  dl_file(
+    url = "https://www.abs.gov.au/statistics",
+    destfile = stats_page_file
+  )
 
   abs_stats_page <- xml2::read_html(stats_page_file)
 
@@ -42,10 +44,11 @@ scrape_abs_catalogues <- function() {
   # scrape each page
 
   scrape_sub_page <- function(heading, sub_page_url_suffix) {
-
     sub_page_file <- tempfile(fileext = ".html")
-    dl_file(url = glue::glue("https://www.abs.gov.au{sub_page_url_suffix}"),
-            destfile = sub_page_file)
+    dl_file(
+      url = glue::glue("https://www.abs.gov.au{sub_page_url_suffix}"),
+      destfile = sub_page_file
+    )
 
     sub_page <- xml2::read_html(sub_page_file)
 
@@ -72,9 +75,11 @@ scrape_abs_catalogues <- function() {
   }
 
 
-  new_abs_lookup_table <- purrr::map2_dfr(.x = main_page_data$heading,
-                                          .y = main_page_data$url_suffix,
-                                          scrape_sub_page)
+  new_abs_lookup_table <- purrr::map2_dfr(
+    .x = main_page_data$heading,
+    .y = main_page_data$url_suffix,
+    scrape_sub_page
+  )
 
   new_abs_lookup_table
 }

--- a/R/search_catalogues.R
+++ b/R/search_catalogues.R
@@ -30,14 +30,17 @@ search_catalogues <- function(string, refresh = FALSE) {
   # Using dplyr::if_any() is fast and clean but requires dplyr >= 1.0.4
   if (getNamespaceVersion("dplyr") > "1.0.4") {
     out <- df %>%
-        dplyr::filter(dplyr::if_any(.cols = dplyr::everything(),
-                                    ~grepl(string, .x,
-                                           perl = TRUE, ignore.case = TRUE)))
-
+      dplyr::filter(dplyr::if_any(
+        .cols = dplyr::everything(),
+        ~ grepl(string, .x,
+          perl = TRUE, ignore.case = TRUE
+        )
+      ))
   } else {
     matches <- purrr::map_dfr(df,
-                          grepl,
-                          pattern = string, perl = TRUE, ignore.case = TRUE) %>%
+      grepl,
+      pattern = string, perl = TRUE, ignore.case = TRUE
+    ) %>%
       rowSums()
 
     out <- dplyr::tibble(sum_true = matches) %>%
@@ -50,5 +53,4 @@ search_catalogues <- function(string, refresh = FALSE) {
     dplyr::mutate(url = as.character(url))
 
   return(out)
-
 }

--- a/R/search_files.R
+++ b/R/search_files.R
@@ -6,23 +6,30 @@
 #' list of files within the catalogue.
 #' @export
 #' @examples
-#' \dontrun{  search_files("GM1", "labour-force-australia") }
-
+#' \dontrun{
+#' search_files("GM1", "labour-force-australia")
+#' }
+#'
 search_files <- function(string, catalogue, refresh = FALSE) {
-  files <- show_available_files(catalogue_string = catalogue,
-                                refresh = refresh)
+  files <- show_available_files(
+    catalogue_string = catalogue,
+    refresh = refresh
+  )
 
   # Using dplyr::if_any() is fast and clean but requires dplyr >= 1.0.4
   if (getNamespaceVersion("dplyr") > "1.0.4") {
     out <- files %>%
-      dplyr::filter(dplyr::if_any(.cols = dplyr::everything(),
-                                  ~grepl(string, .x,
-                                         perl = TRUE, ignore.case = TRUE)))
-
+      dplyr::filter(dplyr::if_any(
+        .cols = dplyr::everything(),
+        ~ grepl(string, .x,
+          perl = TRUE, ignore.case = TRUE
+        )
+      ))
   } else {
     matches <- purrr::map_dfr(files,
-                              grepl,
-                              pattern = string, perl = TRUE, ignore.case = TRUE) %>%
+      grepl,
+      pattern = string, perl = TRUE, ignore.case = TRUE
+    ) %>%
       rowSums()
 
     out <- dplyr::tibble(sum_true = matches) %>%
@@ -36,6 +43,4 @@ search_files <- function(string, catalogue, refresh = FALSE) {
     dplyr::pull(file)
 
   return(out)
-
-
 }

--- a/R/show_available_files.r
+++ b/R/show_available_files.r
@@ -55,10 +55,14 @@ show_available_files <- function(catalogue_string, refresh = FALSE) {
 
 
   # Try to download the page
-  tryCatch({
-    temp_page_location <- file.path(tempdir(), "temp_readabs.html")
-    dl_file(url = download_url,
-            destfile = temp_page_location)},
+  tryCatch(
+    {
+      temp_page_location <- file.path(tempdir(), "temp_readabs.html")
+      dl_file(
+        url = download_url,
+        destfile = temp_page_location
+      )
+    },
     error = function(cond) {
       message(paste("URL does not seem to exist:", download_url))
       message("Here's the original error message:")
@@ -77,8 +81,9 @@ show_available_files <- function(catalogue_string, refresh = FALSE) {
     rvest::html_attr("href")
 
   urls <- ifelse(stringi::stri_sub(urls, 2L, 11L) == "statistics",
-                 paste0("https://www.abs.gov.au", urls),
-                 urls)
+    paste0("https://www.abs.gov.au", urls),
+    urls
+  )
 
   labels <- download_page %>%
     rvest::html_nodes(".abs-data-download-left") %>%
@@ -113,6 +118,8 @@ show_available_files <- function(catalogue_string, refresh = FALSE) {
 #' @export
 
 get_available_files <- function(catalogue_string, refresh = FALSE) {
-  show_available_files(catalogue_string = catalogue_string,
-                       refresh = refresh)
+  show_available_files(
+    catalogue_string = catalogue_string,
+    refresh = refresh
+  )
 }

--- a/R/tidy_abs.R
+++ b/R/tidy_abs.R
@@ -81,11 +81,13 @@ tidy_abs <- function(df, metadata = TRUE) {
   if (isTRUE(metadata)) {
     df <- df %>%
       tidyr::pivot_longer(cols = !one_of("X__1"), names_to = "series") %>%
-      filter(!is.na(X__1),
-             # This filtering is necessary for cases where the ABS adds notes
-             # to the bottom of the data for some reason
-             !stringi::stri_detect_fixed(X__1, "Trend Break"),
-             !stringi::stri_detect_fixed(X__1, "see")) %>%
+      filter(
+        !is.na(X__1),
+        # This filtering is necessary for cases where the ABS adds notes
+        # to the bottom of the data for some reason
+        !stringi::stri_detect_fixed(X__1, "Trend Break"),
+        !stringi::stri_detect_fixed(X__1, "see")
+      ) %>%
       dplyr::group_by(series) %>%
       dplyr::mutate(
         series_type = value[X__1 == "Series Type"],

--- a/data-raw/create_awe_objects.R
+++ b/data-raw/create_awe_objects.R
@@ -8,14 +8,15 @@ library(purrr)
 #' @param url URL from which to download the file if it doesn't exist locally
 dl_if_not <- function(file, url) {
   if (!file.exists(file)) {
-
     if (!dir.exists(dirname(file))) {
       dir.create(dirname(file), recursive = TRUE)
     }
 
-    utils::download.file(url = url,
-                         headers = readabs_header,
-                         destfile = file)
+    utils::download.file(
+      url = url,
+      headers = readabs_header,
+      destfile = file
+    )
   }
 }
 
@@ -25,25 +26,36 @@ dl_if_not <- function(file, url) {
 #' second is file to May 2012.
 load_old_awe <- function(table_num,
                          urls) {
-
-  filenames <- paste0(c("awe_to_may09_t",
-                        "awe_to_may12_t"),
-                      table_num,
-                      ".xls")
+  filenames <- paste0(
+    c(
+      "awe_to_may09_t",
+      "awe_to_may12_t"
+    ),
+    table_num,
+    ".xls"
+  )
 
   old_awote_dir <- file.path("data-raw", "old_awe")
   filenames_incl_path <- file.path(old_awote_dir, filenames)
 
-  purrr::walk2(.x = filenames_incl_path,
-               .y = urls,
-               .f = dl_if_not)
+  purrr::walk2(
+    .x = filenames_incl_path,
+    .y = urls,
+    .f = dl_if_not
+  )
 
-  list_of_dfs <- purrr::map(.x = filenames,
-                            .f = ~read_abs_local(filenames = .x,
-                                                 path = old_awote_dir))
+  list_of_dfs <- purrr::map(
+    .x = filenames,
+    .f = ~ read_abs_local(
+      filenames = .x,
+      path = old_awote_dir
+    )
+  )
 
-  list_of_dfs <- purrr::map(.x = list_of_dfs,
-                            .f = tidy_awe)
+  list_of_dfs <- purrr::map(
+    .x = list_of_dfs,
+    .f = tidy_awe
+  )
 
   list_of_dfs[[1]] <- list_of_dfs[[1]] %>%
     dplyr::filter(!.data$date %in% list_of_dfs[[2]]$date)
@@ -54,31 +66,57 @@ load_old_awe <- function(table_num,
 }
 
 
-urls <- list("2" = c("https://www.abs.gov.au/AUSSTATS/ABS@Archive.nsf/log?openagent&6302002.xls&6302.0&Time%20Series%20Spreadsheet&5379E96E39273CF5CA25761000199DDA&0&May%202009&13.08.2009&Latest",
-                     "https://www.abs.gov.au/ausstats/meisubs.NSF/log?openagent&6302002.xls&6302.0&Time%20Series%20Spreadsheet&16F1263CC960388CCA257A5B00121514&0&May%202012&16.08.2012&Latest"),
-             "5" = c("https://www.abs.gov.au/AUSSTATS/ABS@Archive.nsf/log?openagent&6302005.xls&6302.0&Time%20Series%20Spreadsheet&050F0580F25B65E3CA2576100019ABA5&0&May%202009&13.08.2009&Latest",
-                     "https://www.abs.gov.au/ausstats/meisubs.NSF/log?openagent&6302005.xls&6302.0&Time%20Series%20Spreadsheet&1E27AEE93FD82D5BCA257A5B00121697&0&May%202012&16.08.2012&Latest"),
-             "8" = c("https://www.abs.gov.au/AUSSTATS/ABS@Archive.nsf/log?openagent&6302008.xls&6302.0&Time%20Series%20Spreadsheet&AFD09874D98173D1CA2576100019B97A&0&May%202009&13.08.2009&Latest",
-                     "https://www.abs.gov.au/ausstats/meisubs.NSF/log?openagent&6302008.xls&6302.0&Time%20Series%20Spreadsheet&42F0D3762EA4B015CA257A5B00121828&0&May%202012&16.08.2012&Latest"),
-             "12a" = c("https://www.abs.gov.au/AUSSTATS/ABS@Archive.nsf/log?openagent&63020012a.xls&6302.0&Time%20Series%20Spreadsheet&9CBA3F3531072C68CA257610001A1011&0&May%202009&13.08.2009&Latest",
-                       "https://www.abs.gov.au/ausstats/meisubs.NSF/log?openagent&63020012a.xls&6302.0&Time%20Series%20Spreadsheet&3995977F136AE267CA257A5B00122365&0&May%202012&16.08.2012&Latest"),
-             "12b" = c("https://www.abs.gov.au/AUSSTATS/ABS@Archive.nsf/log?openagent&63020012b.xls&6302.0&Time%20Series%20Spreadsheet&BC330F9D522D37CBCA257610001A146D&0&May%202009&13.08.2009&Latest",
-                       "https://www.abs.gov.au/ausstats/meisubs.NSF/log?openagent&63020012b.xls&6302.0&Time%20Series%20Spreadsheet&57BAD981956F9A5ACA257A5B001223F1&0&May%202012&16.08.2012&Latest"),
-             "12c" = c("https://www.abs.gov.au/AUSSTATS/ABS@Archive.nsf/log?openagent&63020012c.xls&6302.0&Time%20Series%20Spreadsheet&D55540AAEF0F7108CA257610001A192B&0&May%202009&13.08.2009&Latest",
-                       "https://www.abs.gov.au/ausstats/meisubs.NSF/log?openagent&63020012c.xls&6302.0&Time%20Series%20Spreadsheet&B470FF63181FF706CA257A5B00122482&0&May%202012&16.08.2012&Latest"),
-             "12d" = c("https://www.abs.gov.au/AUSSTATS/ABS@Archive.nsf/log?openagent&63020012d.xls&6302.0&Time%20Series%20Spreadsheet&1366F0763440DE6FCA257610001A1D64&0&May%202009&13.08.2009&Latest",
-                       "https://www.abs.gov.au/ausstats/meisubs.NSF/log?openagent&63020012d.xls&6302.0&Time%20Series%20Spreadsheet&C30CF3491B8A00D6CA257A5B00122516&0&May%202012&16.08.2012&Latest"),
-             "12e" = c("https://www.abs.gov.au/AUSSTATS/ABS@Archive.nsf/log?openagent&63020012e.xls&6302.0&Time%20Series%20Spreadsheet&ADD63AF30832FD46CA257610001A225C&0&May%202009&13.08.2009&Latest",
-                       "https://www.abs.gov.au/ausstats/meisubs.NSF/log?openagent&63020012e.xls&6302.0&Time%20Series%20Spreadsheet&3CEB8E4A42304296CA257A5B001225B4&0&May%202012&16.08.2012&Latest"),
-             "12f" = c("https://www.abs.gov.au/AUSSTATS/ABS@Archive.nsf/log?openagent&63020012f.xls&6302.0&Time%20Series%20Spreadsheet&D04EA449744101C8CA257610001A26C1&0&May%202009&13.08.2009&Latest",
-                       "https://www.abs.gov.au/ausstats/meisubs.NSF/log?openagent&63020012f.xls&6302.0&Time%20Series%20Spreadsheet&3640583B53FBC62FCA257A5B0012264D&0&May%202012&16.08.2012&Latest"),
-             "12g" = c("https://www.abs.gov.au/AUSSTATS/ABS@Archive.nsf/log?openagent&63020012g.xls&6302.0&Time%20Series%20Spreadsheet&EDE65E09FE65B9BFCA257610001A2B10&0&May%202009&13.08.2009&Latest",
-                       "https://www.abs.gov.au/ausstats/meisubs.NSF/log?openagent&63020012g.xls&6302.0&Time%20Series%20Spreadsheet&52059A2FFE4E535CCA257A5B001226E7&0&May%202012&16.08.2012&Latest"),
-             "12h" = c("https://www.abs.gov.au/AUSSTATS/ABS@Archive.nsf/log?openagent&63020012h.xls&6302.0&Time%20Series%20Spreadsheet&DD449B1CA7952AE6CA257610001A2FA2&0&May%202009&13.08.2009&Latest",
-                       "https://www.abs.gov.au/ausstats/meisubs.NSF/log?openagent&63020012h.xls&6302.0&Time%20Series%20Spreadsheet&023408E38EFA4936CA257A5B00122775&0&May%202012&16.08.2012&Latest"))
+urls <- list(
+  "2" = c(
+    "https://www.abs.gov.au/AUSSTATS/ABS@Archive.nsf/log?openagent&6302002.xls&6302.0&Time%20Series%20Spreadsheet&5379E96E39273CF5CA25761000199DDA&0&May%202009&13.08.2009&Latest",
+    "https://www.abs.gov.au/ausstats/meisubs.NSF/log?openagent&6302002.xls&6302.0&Time%20Series%20Spreadsheet&16F1263CC960388CCA257A5B00121514&0&May%202012&16.08.2012&Latest"
+  ),
+  "5" = c(
+    "https://www.abs.gov.au/AUSSTATS/ABS@Archive.nsf/log?openagent&6302005.xls&6302.0&Time%20Series%20Spreadsheet&050F0580F25B65E3CA2576100019ABA5&0&May%202009&13.08.2009&Latest",
+    "https://www.abs.gov.au/ausstats/meisubs.NSF/log?openagent&6302005.xls&6302.0&Time%20Series%20Spreadsheet&1E27AEE93FD82D5BCA257A5B00121697&0&May%202012&16.08.2012&Latest"
+  ),
+  "8" = c(
+    "https://www.abs.gov.au/AUSSTATS/ABS@Archive.nsf/log?openagent&6302008.xls&6302.0&Time%20Series%20Spreadsheet&AFD09874D98173D1CA2576100019B97A&0&May%202009&13.08.2009&Latest",
+    "https://www.abs.gov.au/ausstats/meisubs.NSF/log?openagent&6302008.xls&6302.0&Time%20Series%20Spreadsheet&42F0D3762EA4B015CA257A5B00121828&0&May%202012&16.08.2012&Latest"
+  ),
+  "12a" = c(
+    "https://www.abs.gov.au/AUSSTATS/ABS@Archive.nsf/log?openagent&63020012a.xls&6302.0&Time%20Series%20Spreadsheet&9CBA3F3531072C68CA257610001A1011&0&May%202009&13.08.2009&Latest",
+    "https://www.abs.gov.au/ausstats/meisubs.NSF/log?openagent&63020012a.xls&6302.0&Time%20Series%20Spreadsheet&3995977F136AE267CA257A5B00122365&0&May%202012&16.08.2012&Latest"
+  ),
+  "12b" = c(
+    "https://www.abs.gov.au/AUSSTATS/ABS@Archive.nsf/log?openagent&63020012b.xls&6302.0&Time%20Series%20Spreadsheet&BC330F9D522D37CBCA257610001A146D&0&May%202009&13.08.2009&Latest",
+    "https://www.abs.gov.au/ausstats/meisubs.NSF/log?openagent&63020012b.xls&6302.0&Time%20Series%20Spreadsheet&57BAD981956F9A5ACA257A5B001223F1&0&May%202012&16.08.2012&Latest"
+  ),
+  "12c" = c(
+    "https://www.abs.gov.au/AUSSTATS/ABS@Archive.nsf/log?openagent&63020012c.xls&6302.0&Time%20Series%20Spreadsheet&D55540AAEF0F7108CA257610001A192B&0&May%202009&13.08.2009&Latest",
+    "https://www.abs.gov.au/ausstats/meisubs.NSF/log?openagent&63020012c.xls&6302.0&Time%20Series%20Spreadsheet&B470FF63181FF706CA257A5B00122482&0&May%202012&16.08.2012&Latest"
+  ),
+  "12d" = c(
+    "https://www.abs.gov.au/AUSSTATS/ABS@Archive.nsf/log?openagent&63020012d.xls&6302.0&Time%20Series%20Spreadsheet&1366F0763440DE6FCA257610001A1D64&0&May%202009&13.08.2009&Latest",
+    "https://www.abs.gov.au/ausstats/meisubs.NSF/log?openagent&63020012d.xls&6302.0&Time%20Series%20Spreadsheet&C30CF3491B8A00D6CA257A5B00122516&0&May%202012&16.08.2012&Latest"
+  ),
+  "12e" = c(
+    "https://www.abs.gov.au/AUSSTATS/ABS@Archive.nsf/log?openagent&63020012e.xls&6302.0&Time%20Series%20Spreadsheet&ADD63AF30832FD46CA257610001A225C&0&May%202009&13.08.2009&Latest",
+    "https://www.abs.gov.au/ausstats/meisubs.NSF/log?openagent&63020012e.xls&6302.0&Time%20Series%20Spreadsheet&3CEB8E4A42304296CA257A5B001225B4&0&May%202012&16.08.2012&Latest"
+  ),
+  "12f" = c(
+    "https://www.abs.gov.au/AUSSTATS/ABS@Archive.nsf/log?openagent&63020012f.xls&6302.0&Time%20Series%20Spreadsheet&D04EA449744101C8CA257610001A26C1&0&May%202009&13.08.2009&Latest",
+    "https://www.abs.gov.au/ausstats/meisubs.NSF/log?openagent&63020012f.xls&6302.0&Time%20Series%20Spreadsheet&3640583B53FBC62FCA257A5B0012264D&0&May%202012&16.08.2012&Latest"
+  ),
+  "12g" = c(
+    "https://www.abs.gov.au/AUSSTATS/ABS@Archive.nsf/log?openagent&63020012g.xls&6302.0&Time%20Series%20Spreadsheet&EDE65E09FE65B9BFCA257610001A2B10&0&May%202009&13.08.2009&Latest",
+    "https://www.abs.gov.au/ausstats/meisubs.NSF/log?openagent&63020012g.xls&6302.0&Time%20Series%20Spreadsheet&52059A2FFE4E535CCA257A5B001226E7&0&May%202012&16.08.2012&Latest"
+  ),
+  "12h" = c(
+    "https://www.abs.gov.au/AUSSTATS/ABS@Archive.nsf/log?openagent&63020012h.xls&6302.0&Time%20Series%20Spreadsheet&DD449B1CA7952AE6CA257610001A2FA2&0&May%202009&13.08.2009&Latest",
+    "https://www.abs.gov.au/ausstats/meisubs.NSF/log?openagent&63020012h.xls&6302.0&Time%20Series%20Spreadsheet&023408E38EFA4936CA257A5B00122775&0&May%202012&16.08.2012&Latest"
+  )
+)
 
-awe_old <- map2(.x = names(urls),
-                .y = urls,
-                .f = load_old_awe)
+awe_old <- map2(
+  .x = names(urls),
+  .y = urls,
+  .f = load_old_awe
+)
 
 awe_old <- setNames(awe_old, names(urls))

--- a/data-raw/create_internal_data.r
+++ b/data-raw/create_internal_data.r
@@ -18,9 +18,8 @@ abs_lookup_table <- scrape_abs_catalogues()
 data_last_updated <- Sys.Date()
 
 usethis::use_data(abs_lookup_table, data_last_updated,
-                  awe_old,
-                  readabs_user_agent,
-                  readabs_header,
+  awe_old,
+  readabs_user_agent,
+  readabs_header,
   overwrite = TRUE, internal = TRUE
 )
-

--- a/man/download_abs_data_cube.Rd
+++ b/man/download_abs_data_cube.Rd
@@ -52,7 +52,6 @@ The easiest way to edit this file is using \code{usethis::edit_r_environ()}.
 The filepath is returned invisibly which enables piping to \code{unzip()} or \code{readxl::read_excel}.
 }
 \examples{
-
 \dontrun{
 download_abs_data_cube(
   catalogue_string = "labour-force-australia-detailed",

--- a/man/read_abs.Rd
+++ b/man/read_abs.Rd
@@ -13,7 +13,8 @@ read_abs(
   metadata = TRUE,
   show_progress_bars = TRUE,
   retain_files = TRUE,
-  check_local = TRUE
+  check_local = TRUE,
+  release_date = "latest"
 )
 
 read_abs_series(series_id, ...)
@@ -51,6 +52,11 @@ If set to `FALSE`, the files will be stored in a temporary directory.}
 
 \item{check_local}{If `TRUE`, the default, local `fst` files are used,
 if present.}
+
+\item{release_date}{Either `"latest"` or a string coercible to a date, such as
+`"2022-02-01"`. If `"latest"`, the latest release of the requested data will
+be returned. If a date, (eg. `"2022-02-01"`) `read_abs()` will
+attempt to download the data from that month's release.}
 
 \item{...}{Arguments to `read_abs_series()` are passed to `read_abs()`.}
 }
@@ -95,10 +101,16 @@ wpi <- read_abs("6345.0")
 wpi_t1 <- read_abs("6345.0", tables = "1")
 }
 
+# Or table 1 as in the Sep 2019 release of the WPI:
+\dontrun{
+wpi_t1_sep2019 <- read_abs("6345.0", tables = "1", release_date = "2019-09-01")
+}
+
 # Or tables 1 and 2a from the WPI
 \dontrun{
 wpi_t1_t2a <- read_abs("6345.0", tables = c("1", "2a"))
 }
+
 
 # Get two specific time series, based on their time series IDs
 \dontrun{

--- a/man/read_abs.Rd
+++ b/man/read_abs.Rd
@@ -56,7 +56,7 @@ if present.}
 \item{release_date}{Either `"latest"` or a string coercible to a date, such as
 `"2022-02-01"`. If `"latest"`, the latest release of the requested data will
 be returned. If a date, (eg. `"2022-02-01"`) `read_abs()` will
-attempt to download the data from that month's release.}
+attempt to download the data from that month's release. See `Details`.}
 
 \item{...}{Arguments to `read_abs_series()` are passed to `read_abs()`.}
 }
@@ -87,6 +87,12 @@ for a single session using \code{Sys.setenv(R_READABS_PATH = <path>)}.
 If you would like to change this variable for all future R sessions, edit
 your `.Renviron` file and add \code{R_READABS_PATH = <path>} line.
 The easiest way to edit this file is using \code{usethis::edit_r_environ()}.
+
+The `release_date` argument allows you to download table(s) other than the
+latest release. This is useful for examining revisions to time series, or
+for obtaining the version of series that were available on a given date.
+Note that you cannot supply more than one date to `release_date`. Note also
+that any dates prior to mid-2019 (the exact date varies by series) will fail.
 }
 \examples{
 

--- a/man/read_lfs_grossflows.Rd
+++ b/man/read_lfs_grossflows.Rd
@@ -34,4 +34,5 @@ transitioned from one labour force status to another between two months.
 \dontrun{
 read_lfs_grossflows()
 }
+
 }

--- a/man/search_files.Rd
+++ b/man/search_files.Rd
@@ -18,5 +18,8 @@ list of files within the catalogue.}
 Search for a file within an ABS catalogue
 }
 \examples{
-\dontrun{  search_files("GM1", "labour-force-australia") }
+\dontrun{
+search_files("GM1", "labour-force-australia")
+}
+
 }

--- a/tests/testthat/test-check_latest_date.R
+++ b/tests/testthat/test-check_latest_date.R
@@ -1,5 +1,4 @@
 test_that("check_latest_date() returns expected output", {
-
   skip_on_cran()
   skip_if_offline()
   skip_if_not(check_abs_connection())
@@ -11,15 +10,18 @@ test_that("check_latest_date() returns expected output", {
     expect_gt(result, Sys.Date() - 180)
   }
 
-  whole_cat <-  check_latest_date("6345.0")
+  whole_cat <- check_latest_date("6345.0")
   single_table <- check_latest_date("6202.0", tables = 1)
   two_tables <- check_latest_date("6345.0", tables = c("1", "5a"))
   single_series <- check_latest_date(series_id = "A2713849C")
 
-  purrr::map(c(whole_cat,
-               single_table,
-               two_tables,
-               single_series),
-             test_latest_date)
-
+  purrr::map(
+    c(
+      whole_cat,
+      single_table,
+      two_tables,
+      single_series
+    ),
+    test_latest_date
+  )
 })

--- a/tests/testthat/test-local-files.R
+++ b/tests/testthat/test-local-files.R
@@ -75,8 +75,10 @@ test_that("read_abs_local() returns appropriate errors and messages", {
 })
 
 test_that("read_abs_local() reads an XLSX file", {
-  lfs_21_xlsx <- read_abs_local(filenames = "6202021.xlsx",
-                 path = local_path)
+  lfs_21_xlsx <- read_abs_local(
+    filenames = "6202021.xlsx",
+    path = local_path
+  )
 
   expect_s3_class(lfs_21_xlsx, "tbl_df")
   expect_length(lfs_21_xlsx, 12)

--- a/tests/testthat/test-match_tables.R
+++ b/tests/testthat/test-match_tables.R
@@ -6,7 +6,6 @@ test_match_tables <- function(cat_no, tables) {
 }
 
 test_that("match_tables() returns only requested tables", {
-
   skip_on_cran()
 
   t1 <- test_match_tables("5368.0", "1")
@@ -33,8 +32,10 @@ test_that("match_tables() returns only requested tables", {
   t6 <- test_match_tables("6291.0.55.001", "1")
   expect_length(t6, 1)
 
-  t7 <- test_match_tables("6202.0",
-                          c("1", "4", "10a", "11", "11a", "12", "12a", "21"))
+  t7 <- test_match_tables(
+    "6202.0",
+    c("1", "4", "10a", "11", "11a", "12", "12a", "21")
+  )
   expect_length(t7, 8)
 
   t8 <- test_match_tables("5368.0", c("12a", "13a"))

--- a/tests/testthat/test-old-functions.R
+++ b/tests/testthat/test-old-functions.R
@@ -28,4 +28,3 @@ test_that("Old read_abs_metadata() function imports a spreadsheet", {
 
   expect_equal(length(colnames(local_file)), 9)
 })
-

--- a/tests/testthat/test-read_awe.R
+++ b/tests/testthat/test-read_awe.R
@@ -1,7 +1,7 @@
 test_that("tidy_awe() returns tidied data frame", {
-
   awe <- readxl::read_excel(file.path("..", "testdata", "6302002.xls"),
-                            sheet = "Data1")
+    sheet = "Data1"
+  )
 
   awe <- tidy_abs(awe)
 
@@ -11,7 +11,7 @@ test_that("tidy_awe() returns tidied data frame", {
   expect_equal(nrow(tidied_awe), 927)
   expect_true(all(
     c("date", "sex", "wage_measure", "value") %in% names(tidied_awe)
-                   ))
+  ))
   expect_false(any(is.na(tidied_awe$value)))
 })
 
@@ -27,34 +27,41 @@ test_that("read_awe() returns expected output", {
   expect_identical(min(no_params$date), as.Date("1983-11-15"))
   expect_gt(max(no_params$date), as.Date("2020-05-14"))
   expect_is(no_params$value, "numeric")
-  expect_gt(max(no_params$value, na.rm = T) /
-              min(no_params$value, na.rm = T),
-            4.5)
+  expect_gt(
+    max(no_params$value, na.rm = T) /
+      min(no_params$value, na.rm = T),
+    4.5
+  )
 
-  params_df <- expand.grid(sex = c("persons", "males", "females"),
-              wage_measure = c("awote", "ftawe", "awe"),
-              sector = c("total", "private", "public"),
-              state = c("all",
-                        "nsw",
-                        "vic",
-                        "qld",
-                        "sa",
-                        "wa",
-                        "tas",
-                        "nt",
-                        "act"),
-              stringsAsFactors = FALSE)
+  params_df <- expand.grid(
+    sex = c("persons", "males", "females"),
+    wage_measure = c("awote", "ftawe", "awe"),
+    sector = c("total", "private", "public"),
+    state = c(
+      "all",
+      "nsw",
+      "vic",
+      "qld",
+      "sa",
+      "wa",
+      "tas",
+      "nt",
+      "act"
+    ),
+    stringsAsFactors = FALSE
+  )
 
   params_df <- params_df %>%
     dplyr::filter(sector == "total" | state == "all")
 
 
   for (i in seq_len(nrow(params_df))) {
-
-    awe_data <- read_awe(wage_measure = params_df$wage_measure[i],
-             sex = params_df$sex[i],
-             sector = params_df$sector[i],
-             state = params_df$state[i])
+    awe_data <- read_awe(
+      wage_measure = params_df$wage_measure[i],
+      sex = params_df$sex[i],
+      sector = params_df$sector[i],
+      state = params_df$state[i]
+    )
 
     expect_is(awe_data, "tbl_df")
 
@@ -75,7 +82,6 @@ test_that("read_awe() returns expected output", {
       expect_length(awe_data, 5)
       expect_true("state" %in% names(awe_data))
     }
-
   }
 
 

--- a/tests/testthat/test-read_job_mobility.R
+++ b/tests/testthat/test-read_job_mobility.R
@@ -2,19 +2,23 @@ test_that("read_job_mobility() works as expected", {
   test_mobility_df <- function(df) {
     expect_length(df, 12)
     expect_gt(nrow(df), 0)
-    expect_identical(names(df),
-                     c("table_no",
-                        "sheet_no",
-                        "table_title",
-                        "date",
-                        "series",
-                        "value",
-                        "series_type",
-                        "data_type",
-                        "collection_month",
-                        "frequency",
-                        "series_id",
-                        "unit"))
+    expect_identical(
+      names(df),
+      c(
+        "table_no",
+        "sheet_no",
+        "table_title",
+        "date",
+        "series",
+        "value",
+        "series_type",
+        "data_type",
+        "collection_month",
+        "frequency",
+        "series_id",
+        "unit"
+      )
+    )
     expect_is(df$value, "numeric")
     expect_is(df$date, "Date")
   }

--- a/tests/testthat/test-read_lfs_grossflows.R
+++ b/tests/testthat/test-read_lfs_grossflows.R
@@ -1,5 +1,4 @@
 test_that("read_lfs_grossflows() downloads and imports LFS cube GM1", {
-
   skip_if_offline()
   skip_on_cran()
 
@@ -11,8 +10,10 @@ test_that("read_lfs_grossflows() downloads and imports LFS cube GM1", {
   options("timeout" = prev_option)
 
   # Current should still be the default
-  expect_identical(unique(gf_cur$weights),
-                   "current month")
+  expect_identical(
+    unique(gf_cur$weights),
+    "current month"
+  )
 
   # Pass minimal tests
   expect_true(check_lfs_grossflows(gf_cur))

--- a/tests/testthat/test-readabs.R
+++ b/tests/testthat/test-readabs.R
@@ -175,6 +175,9 @@ test_that("previous vintages of time series can be loaded", {
     "tbl_df"
   )
 
-  expect_error(read_abs("6345.0", 1, release_date = "2020-03"))
-  expect_error(read_abs("6345.0", 1, release_date = c("2020-03-01", "2020-06-01")))
+  expect_error(read_abs("6345.0", 1, release_date = "2020-03",
+                        check_local = F))
+
+  expect_error(read_abs("6345.0", 1, release_date = c("2020-03-01", "2020-06-01")
+                        , check_local = F))
 })

--- a/tests/testthat/test-readabs.R
+++ b/tests/testthat/test-readabs.R
@@ -174,4 +174,7 @@ test_that("previous vintages of time series can be loaded", {
     read_abs("6345.0", 1, release_date = "2020-03-01", check_local = F),
     "tbl_df"
   )
+
+  expect_error(read_abs("6345.0", 1, release_date = "2020-03"))
+  expect_error(read_abs("6345.0", 1, release_date = c("2020-03-01", "2020-06-01")))
 })

--- a/tests/testthat/test-readabs.R
+++ b/tests/testthat/test-readabs.R
@@ -75,7 +75,6 @@ test_that("read_abs() works with series ID(s)", {
   cpi_wrapper <- read_abs_series(series_id = c("A2325846C", "A2325841T"), retain_files = FALSE, check_local = F, path = tempdir())
 
   expect_identical(cpi_2, cpi_wrapper)
-
 })
 
 
@@ -171,7 +170,8 @@ test_that("previous vintages of time series can be loaded", {
   skip_if_offline()
   check_abs_connection()
 
-  expect_s3_class(read_abs("6345.0", 1, release_date = "2020-03-01", check_local = F),
-                  "tbl_df")
+  expect_s3_class(
+    read_abs("6345.0", 1, release_date = "2020-03-01", check_local = F),
+    "tbl_df"
+  )
 })
-

--- a/tests/testthat/test-readabs.R
+++ b/tests/testthat/test-readabs.R
@@ -166,3 +166,12 @@ test_that("3401.0 table 1 can be loaded", {
   expect_s3_class(read_abs("3401.0", "1"), "tbl_df")
 })
 
+test_that("previous vintages of time series can be loaded", {
+  skip_on_cran()
+  skip_if_offline()
+  check_abs_connection()
+
+  expect_s3_class(read_abs("6345.0", 1, release_date = "2020-03-01", check_local = F),
+                  "tbl_df")
+})
+

--- a/tests/testthat/test-search_catalogues.R
+++ b/tests/testthat/test-search_catalogues.R
@@ -10,7 +10,7 @@ test_that("search_catalogues() returns appropriate output", {
   expect_is(lab, "tbl")
   expect_length(lab, 4)
   expect_gt(nrow(lab), 20)
-  expect_true(all(purrr::map_lgl(lab, ~inherits(.x, "character"))))
+  expect_true(all(purrr::map_lgl(lab, ~ inherits(.x, "character"))))
 
   expect_true(nrow(search_catalogues("foobar")) == 0)
 })
@@ -25,5 +25,4 @@ test_that("search_catalogues() refreshes table when requested", {
   expect_is(ref, "tbl")
   expect_length(ref, 4)
   expect_gt(nrow(ref), 4)
-
 })


### PR DESCRIPTION
This adds a `release_date` argument to `read_abs()`. 

At the moment, `read_abs()` fetches the latest release of the requested table(s). It cannot be used to fetch previous releases. 

The `release_date` argument allows previous releases to be retrieved. Note that it does not work for anything released prior to the launch of the current ABS website (mid-2019). 

Keen for input on this PR.