### PR TITLE
Update read_cpi()  to pull from the quarterly CPI (Table 17)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,7 +35,7 @@ Imports:
     labelled
 URL: https://github.com/mattcowgill/readabs
 BugReports: https://github.com/mattcowgill/readabs/issues
-RoxygenNote: 7.3.2
+RoxygenNote: 7.3.3
 VignetteBuilder: knitr
 Suggests: 
     knitr,

--- a/R/read_cpi.R
+++ b/R/read_cpi.R
@@ -1,12 +1,12 @@
 #' Download a tidy tibble containing the Consumer Price Index from the ABS
 #'
 #' \code{read_cpi()} uses the \code{read_abs()} function to download, import,
-#' and tidy the Consumer Price Index from the ABS. It returns a tibble
+#' and tidy the quarterly Consumer Price Index from the ABS. It returns a tibble
 #' containing two columns: the date and the CPI index value that corresponds
 #' to that date. This makes joining the CPI to another dataframe easy.
 #' \code{read_cpi()} returns the original (ie. not seasonally adjusted)
-#' all groups CPI for Australia. If you want the analytical series
-#' (eg. seasonally adjusted CPI, or trimmed mean CPI), you can use
+#' quarterly all groups CPI for Australia. If you want the analytical series
+#' (eg. seasonally adjusted CPI, or trimmed mean CPI) or monthly series, you can use
 #' \code{read_abs()}.
 #'
 #' @param path character; default is "data/ABS". Only used if
@@ -57,7 +57,7 @@ read_cpi <- function(path = Sys.getenv("R_READABS_PATH", unset = tempdir()),
 
   cpi_raw <- read_abs(
     cat_no = "6401.0",
-    tables = 1,
+    tables = 17,
     retain_files = retain_files,
     check_local = check_local,
     show_progress_bars = show_progress_bars,

--- a/man/read_cpi.Rd
+++ b/man/read_cpi.Rd
@@ -27,12 +27,12 @@ directory specified with 'path'.}
 }
 \description{
 \code{read_cpi()} uses the \code{read_abs()} function to download, import,
-and tidy the Consumer Price Index from the ABS. It returns a tibble
+and tidy the quarterly Consumer Price Index from the ABS. It returns a tibble
 containing two columns: the date and the CPI index value that corresponds
 to that date. This makes joining the CPI to another dataframe easy.
 \code{read_cpi()} returns the original (ie. not seasonally adjusted)
-all groups CPI for Australia. If you want the analytical series
-(eg. seasonally adjusted CPI, or trimmed mean CPI), you can use
+quarterly all groups CPI for Australia. If you want the analytical series
+(eg. seasonally adjusted CPI, or trimmed mean CPI) or monthly series, you can use
 \code{read_abs()}.
 }
 \examples{


### PR DESCRIPTION
Since the December 2025 release, the ABS has changed the CPI series to make the monthly series Table 1. However the monthly series only dates back to April 2024 (compared to 1948 for the quarterly). This PR redirects the read_cpi() function to continue to read from the quarterly series instead of the monthly.

This does open a question about the intended purpose of the `read_cpi()` function.

1. Continuing to pull from the monthly CPI table (table 1) would be most simple.
2. Pulling from the quarterly series would arguably be more useful given the longer time horizon (and consistent with previous scripts that use the function).
3. Alternatively an argument could be created to handle both cases depending on user preference.

Further, the function could be rebuilt using `read_api("CPI")` (instead of `read_abs()`) and:

1. Have the option for both monthly, quarterly, or joining them together.
2. Arguments for which region's CPI.
3. Arguments for which analytical series (original, trend, seasonally adjusted).
4. It could even be extended beyond 'All groups CPI' and allow selection of groups/subgroups/classes or even measures (% change (YoY/MoM/QoQ), index, etc). But that might be too complex.  

The above could all be done through `read_abs()` but would be less elegant...However it would have the benefit of being backwards compatible. `read_api()` would render many of the current arguments of `read_cpi()` (`path`, `show progress bars`, `check_local`, `retain_files`), obsolete. 

Happy to go with whichever you prefer and I can amend the PR accordingly. 