### PR TITLE
Add support for tables with two leading zeros

### DIFF
--- a/R/get_abs_xml_metadata.R
+++ b/R/get_abs_xml_metadata.R
@@ -92,10 +92,11 @@ get_specific_xml_page <- function(url, page) {
     first_url <- url
   }
 
-  # Some tables in the ABS TSD start with a leading zero, as in
-  # Table 01 rather than Table 1; the 0 needs to be included. Here we first test
-  # for a readable XML file using the table number supplied (eg. "1"); if that
-  # doesn't work then we try with a leading zero ("01").
+  # Some tables in the ABS TSD start with one or two leading zeros, as in
+  # Table 01 or Table 001 rather than Table 1; the 0 needs to be included. 
+  # Here we first test for a readable XML file using the table number 
+  # supplied (eg. "1"); if that doesn't work then we try with a leading 
+  # zero ("01"), then two leading zeros ("001").
 
   safely_get_xml_dfs <- purrr::safely(get_xml_dfs)
   first_page <- safely_get_xml_dfs(first_url)
@@ -117,9 +118,7 @@ get_specific_xml_page <- function(url, page) {
     }
 
     # now try prepending a 0 on the ttitle
-
     first_url <- gsub("ttitle=", "ttitle=0", first_url)
-
     first_page <- safely_get_xml_dfs(first_url)
 
     first_url_works <- if (!is.null(first_page$result)) {
@@ -131,10 +130,24 @@ get_specific_xml_page <- function(url, page) {
     if (first_url_works) {
       url <- gsub("ttitle=", "ttitle=0", url)
     } else {
-      stop(
-        "Cannot find valid entry for requested data",
-        "in the ABS Time Series Directory"
-      )
+      # now try prepending a 00 on the ttitle
+      first_url <- gsub("ttitle=0", "ttitle=00", first_url)
+      first_page <- safely_get_xml_dfs(first_url)
+
+      first_url_works <- if (!is.null(first_page$result)) {
+        TRUE
+      } else {
+        FALSE
+      }
+
+      if (first_url_works) {
+        url <- gsub("ttitle=", "ttitle=00", url)
+      } else {
+        stop(
+          "Cannot find valid entry for requested data",
+          "in the ABS Time Series Directory"
+        )
+      }
     }
   }
 

--- a/R/get_abs_xml_metadata.R
+++ b/R/get_abs_xml_metadata.R
@@ -145,7 +145,7 @@ get_specific_xml_page <- function(url, page) {
       } else {
         stop(
           "Cannot find valid entry for requested data",
-          "in the ABS Time Series Directory"
+          " in the ABS Time Series Directory"
         )
       }
     }


### PR DESCRIPTION
From the April 2026 reference period, the ABS has changed the table names for the Labour Force Survey. For example, "Table 19" is now "Table 017". A concordance is provided [here](https://www.abs.gov.au/statistics/labour/employment-and-unemployment/labour-force-australia/apr-2026#data-downloads). 

As part of this change, table names are now three characters long ("Table 001"). When searching the ABS TSD, the correct number of leading zeros is required. Currently, a maximum of one leading zero is added, which now fails when searching for single digit tables from the LFS. 

```
r$> dt <- read_abs("6202.0", tables = c("1"))

Finding URLs for tables corresponding to ABS catalogue 6202.0
Error in `map()`:
i In index: 1.
Caused by error in `get_specific_xml_page()`:
! Cannot find valid entry for requested datain the ABS Time Series Directory
Run `rlang::last_trace()` to see where the error occurred.
```

However, the download still works if you add a leading zero manually.
```
r$> dt <- read_abs("6202.0", tables = c("01"))

Finding URLs for tables corresponding to ABS catalogue 6202.0
Attempting to download files from catalogue 6202.0, Labour Force, Australia
trying URL 'https://www.abs.gov.au/statistics/labour/employment-and-unemployment/labour-force-australia/latest-release/62020001.xlsx'
Content type 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' length 768186 bytes (750 KB)
downloaded 750 KB

Extracting data from downloaded spreadsheets
Tidying data from imported ABS spreadsheets  
```

To resolve this, I've simply added another case. It tries adding two leading zeros ("001") if one leading zero ("01") still does not result in a readable XML file. (I don't often work on R packages, so a closer review may be warranted.)